### PR TITLE
[FEAT] msa 공통 라이브러리 초기 구현

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,62 +1,530 @@
 # common-library
+
+MSA 환경에서 공통으로 사용하는 기능을 제공하는 라이브러리입니다.
+
+- 공통 예외 처리 / 응답 포맷
+- Outbox / Inbox 패턴 (Kafka 기반 이벤트 발행 신뢰성 보장)
+- 페이지네이션 (Offset / Cursor)
+- MDC 기반 요청 추적
+
 ---
 
-## 팀원 사용 가이드
+## 목차
 
-### 1. GitHub Personal Access Token 발급
+1. [의존성 추가](#1-의존성-추가)
+2. [소비자 서비스 설정](#2-소비자-서비스-설정)
+3. [예외 처리](#3-예외-처리)
+4. [공통 응답 포맷](#4-공통-응답-포맷)
+5. [Outbox / Inbox 패턴](#5-outbox--inbox-패턴)
+6. [페이지네이션](#6-페이지네이션)
+7. [MDC 요청 추적](#7-mdc-요청-추적)
+8. [버전 히스토리](#8-버전-히스토리)
 
-GitHub Packages에서 패키지를 내려받으려면 **인증 토큰**이 필요합니다.
+---
+
+## 1. 의존성 추가
+
+### GitHub Personal Access Token 발급
+
+GitHub Packages에서 패키지를 내려받으려면 인증 토큰이 필요합니다.
 
 1. GitHub → **Settings** → **Developer settings** → **Personal access tokens** → **Tokens (classic)**
 2. **Generate new token (classic)** 클릭
-3. 권한에서 **`read:packages`** 체크 (다운로드만 할 경우)
+3. 권한에서 **`read:packages`** 체크
 4. 토큰 생성 후 복사 (`ghp_xxxx...`)
 
----
+### Gradle 인증 설정
 
-### 2. Gradle 인증 설정
+발급받은 토큰을 로컬 Gradle 설정 파일에 저장합니다.
 
-발급받은 토큰을 **로컬 Gradle 설정 파일**에 저장합니다.
-> ⚠️ 프로젝트 내부 파일에 절대 넣지 마세요. 깃에 올라갑니다.
+> ⚠️ 프로젝트 내부 파일에 절대 넣지 마세요. git에 올라갑니다.
 
-```
-~/.gradle/gradle.properties
-```
-
-파일을 열어 아래 내용을 추가합니다:
+`~/.gradle/gradle.properties`
 
 ```properties
-gpr.user=본인_깃헙_아이디
-gpr.key=ghp_xxxxxxxxxxxxxxxxxxxx
+GitHubPackagesUsername=본인_깃헙_아이디
+GitHubPackagesPassword=ghp_xxxxxxxxxxxxxxxxxxxx
 ```
 
----
+### build.gradle.kts 설정
 
-### 3. 프로젝트 build.gradle 설정
-
-#### Gradle Groovy DSL
-
-```groovy
+```kotlin
 repositories {
     mavenCentral()
     maven {
         url = uri("https://maven.pkg.github.com/9oogle/common-library")
         credentials {
-            username = findProperty("gpr.user")
-            password = findProperty("gpr.key")
+            username = providers.gradleProperty("GitHubPackagesUsername").get()
+            password = providers.gradleProperty("GitHubPackagesPassword").get()
         }
     }
 }
 
 dependencies {
-    implementation "com.9oogle:common-library:1.0.0"
+    implementation("com.goggles:common-library:1.0.0")
 }
 ```
 
 ---
 
-## 버전 히스토리
+## 2. 소비자 서비스 설정
+
+### EventConfig Import
+
+라이브러리의 모든 빈(Outbox/Inbox, Filter, ArgumentResolver 등)은 `EventConfig` 하나를 import하면 자동 등록됩니다.
+
+```java
+@Import(EventConfig.class)
+@SpringBootApplication
+@EnableJpaAuditing
+public class MyServiceApplication { }
+```
+
+### JPA Auditing 설정
+
+`BaseTime`(`createdAt`, `updatedAt`)은 `@EnableJpaAuditing`만으로 동작합니다.
+
+`BaseAudit`(`createdBy`, `updatedBy`)을 사용하는 엔티티가 있다면 `AuditorAware<UUID>` 빈을 추가로 등록해야 합니다.
+
+```java
+@Bean
+public AuditorAware<UUID> auditorAware() {
+    return () -> Optional.ofNullable(SecurityContextHolder.getContext())
+            .map(ctx -> UUID.fromString(ctx.getAuthentication().getName()));
+}
+```
+
+### 기반 엔티티 선택
+
+| 클래스 | 제공 필드 | 사용 시점 |
+|--------|-----------|-----------|
+| `BaseTime` | `createdAt`, `updatedAt`, `deletedAt` | 작성자 정보가 필요 없을 때 |
+| `BaseAudit` | `BaseTime` + `createdBy`, `updatedBy`, `deletedBy` | 작성자 정보까지 필요할 때 |
+
+```java
+// 작성자 추적이 필요한 엔티티
+@Entity
+public class Order extends BaseAudit { ... }
+
+// 시각 정보만 필요한 엔티티
+@Entity
+public class Outbox extends BaseTime { ... }
+```
+
+---
+
+## 3. 예외 처리
+
+### 예외 계층 구조
+
+```
+RuntimeException
+└── CustomException (status, field 포함)
+    ├── BadRequestException        400
+    ├── UnAuthorizedException      401
+    ├── ForbiddenException         403
+    ├── NotFoundException          404
+    ├── ConflictException          409
+    └── InternalServerException    500
+```
+
+### 도메인별 커스텀 예외 생성 (권장)
+
+각 도메인 서비스에서 위 클래스를 상속받아 도메인에 맞는 예외를 직접 만들어 사용하는 것을 권장합니다. 에러 메시지를 한 곳에서 관리할 수 있습니다.
+
+```java
+// 주문 도메인 예외 예시
+public class OrderNotFoundException extends NotFoundException {
+    public OrderNotFoundException(String orderId) {
+        super("주문을 찾을 수 없습니다. orderId=" + orderId);
+    }
+}
+
+public class OrderAlreadyPaidException extends ConflictException {
+    public OrderAlreadyPaidException(String orderId) {
+        super("이미 결제된 주문입니다. orderId=" + orderId);
+    }
+}
+```
+
+```java
+// 사용
+Order order = orderRepository.findById(orderId)
+        .orElseThrow(() -> new OrderNotFoundException(orderId));
+```
+
+### GlobalExceptionAdvice 처리 목록
+
+`GlobalExceptionAdvice`는 `@RestControllerAdvice`로 등록되며, 아래 예외들을 자동으로 처리합니다.
+
+| 예외 | HTTP 상태 |
+|------|-----------|
+| `CustomException` (및 하위 클래스) | 예외에 설정된 상태 코드 |
+| `MethodArgumentNotValidException` (`@Valid` 실패) | 400 |
+| `ConstraintViolationException` (`@Validated` 실패) | 400 |
+| `HttpMessageNotReadableException` (Body 누락/형식 오류) | 400 |
+| `IllegalArgumentException` | 400 |
+| `OptimisticLockException` | 409 |
+| `Exception` (그 외 모든 예외) | 500 |
+
+### 에러 응답 포맷
+
+```json
+{
+  "status": 404,
+  "error": "NOT_FOUND",
+  "message": "주문을 찾을 수 없습니다. orderId=abc123",
+  "field": null,
+  "traceId": "a3f2bc91",
+  "timestamp": "2025-04-21T10:30:00"
+}
+```
+
+---
+
+## 4. 공통 응답 포맷
+
+`CommonResponseAdvice`가 컨트롤러의 반환값을 자동으로 `ApiResponse`로 감쌉니다. 컨트롤러에서 별도 처리가 필요 없습니다.
+
+```java
+// 컨트롤러
+@GetMapping("/orders/{id}")
+public OrderResponse getOrder(@PathVariable String id) {
+    return orderService.getOrder(id); // ApiResponse로 자동 래핑됨
+}
+```
+
+```json
+{
+  "success": true,
+  "message": "요청이 성공적으로 처리되었습니다.",
+  "data": { ... },
+  "traceId": "a3f2bc91"
+}
+```
+
+메시지를 직접 지정하고 싶다면 `ApiResponse`를 직접 반환합니다.
+
+```java
+return ApiResponse.success("주문이 생성되었습니다.", orderResponse);
+```
+
+---
+
+## 5. Outbox / Inbox 패턴
+
+### 개념
+
+Kafka 메시지 발행은 네트워크 오류, 브로커 장애 등으로 실패할 수 있습니다. 단순히 `kafkaTemplate.send()`를 호출하면 DB 저장은 성공했는데 메시지 발행이 누락되는 상황이 발생할 수 있습니다.
+
+이 문제를 해결하기 위해 **Outbox/Inbox 패턴**을 사용합니다.
+
+- **Outbox**: 발행할 메시지를 DB에 먼저 저장한 뒤 Kafka로 전송. 전송 실패 시 스케줄러가 재시도
+- **Inbox**: 컨슈머 측에서 동일 메시지를 중복으로 처리하지 않도록 멱등성 보장
+
+---
+
+### Outbox 처리 흐름
+
+```
+도메인 서비스                   OutboxEventListener              OutboxRelayScheduler
+─────────────────────────────────────────────────────────────────────────────────────
+Events.trigger()
+  │
+  └─► Spring ApplicationEvent 발행
+            │
+            ▼
+      recordOutbox()          ← @EventListener
+      DB에 PENDING으로 저장
+      (트랜잭션 참여)
+            │
+            ▼ (트랜잭션 커밋 후)
+      publish()               ← @TransactionalEventListener(AFTER_COMMIT)
+      Kafka 전송
+            │
+     ┌──────┴──────┐
+   성공            실패
+     │              │
+  PROCESSED      FAILED + retryCount++
+                    │
+              retryCount >= 3
+                    │
+                  DLT 전송
+                (topic.DLT)
+
+                          스케줄러 (10초마다)
+                          ─────────────────
+                          PENDING/FAILED 조회
+                          → PROCESSING으로 선점
+                          → Kafka 재전송
+                          → PROCESSED/FAILED 업데이트
+                          (5분 이상 PROCESSING stuck → 자동 복구)
+```
+
+---
+
+### Kafka 파티션 키
+
+모든 Outbox 메시지는 `correlationId`를 Kafka 메시지 **키**로 사용합니다.
+
+Kafka는 같은 파티션 내에서만 순서를 보장합니다. 키가 없으면 메시지가 라운드로빈으로 파티션에 분산되어, 동일 엔티티에 대한 이벤트(`order-created` → `order-paid` → `order-cancelled`)가 서로 다른 파티션으로 흩어져 **순서가 역전**될 수 있습니다.
+
+`correlationId`를 키로 사용하면 같은 엔티티의 이벤트가 항상 동일한 파티션으로 전송되어 순서가 보장됩니다. 최초 발행(`publish`)과 스케줄러 재전송(`relay`) 두 경로 모두 동일하게 적용되어 있습니다.
+
+```
+correlationId = "order-abc123"  →  hash("order-abc123") % 파티션 수  →  항상 파티션 2
+```
+
+> `correlationId`는 보통 도메인 엔티티 ID를 사용합니다. 같은 주문에 대한 모든 이벤트가 동일한 파티션으로 묶입니다.
+
+---
+
+### Outbox 사용법
+
+**1. `Events.trigger()` 호출**
+
+도메인 서비스에서 `Events`를 주입받아 이벤트를 발행합니다. 반드시 `@Transactional` 메서드 내에서 호출해야 합니다.
+
+```java
+@Service
+@RequiredArgsConstructor
+public class OrderService {
+
+    private final OrderRepository orderRepository;
+    private final Events events;
+
+    @Transactional
+    public void createOrder(CreateOrderRequest request) {
+        Order order = orderRepository.save(Order.from(request));
+
+        // correlationId: 중복 방지용 고유 ID (보통 도메인 ID 활용)
+        // domainType: 도메인 구분 문자열
+        // eventType: Kafka 토픽명
+        // payload: 전송할 데이터 객체
+        events.trigger(
+                order.getId().toString(),   // correlationId
+                "ORDER",                    // domainType
+                "order-created",            // eventType (= Kafka 토픽)
+                new OrderCreatedPayload(order)
+        );
+    }
+}
+```
+
+**2. DB 마이그레이션**
+
+소비자 서비스의 DB에 `p_outbox` 테이블이 필요합니다.
+
+```sql
+CREATE TABLE p_outbox (
+    id              UUID PRIMARY KEY,
+    correlation_id  VARCHAR(64)  NOT NULL UNIQUE,
+    domain_type     VARCHAR(50)  NOT NULL,
+    event_type      VARCHAR(100) NOT NULL,
+    payload         TEXT,
+    status          VARCHAR(20)  NOT NULL DEFAULT 'PENDING',
+    retry_count     INT          NOT NULL DEFAULT 0,
+    created_at      TIMESTAMP    NOT NULL,
+    updated_at      TIMESTAMP    NOT NULL
+);
+
+CREATE INDEX idx_outbox_status ON p_outbox (status);
+```
+
+---
+
+### Inbox 처리 흐름
+
+```
+Kafka Consumer
+──────────────
+메시지 수신
+  │
+  ▼
+@IdempotentConsumer     ← AOP가 가로챔
+  │
+  ├─► p_inbox에 (messageId, messageGroup) INSERT 시도
+  │         │
+  │    이미 존재   → 중복 메시지 → 처리 건너뜀
+  │         │
+  │    신규 메시지 → 비즈니스 로직 실행
+  │                      │
+  │                   예외 발생 → 트랜잭션 롤백 (Inbox 저장도 취소)
+  │                              → 다음 소비 시 재처리됨
+  │
+  └─► InboxCleanupScheduler: 7일 경과 Inbox 레코드 매일 새벽 3시 삭제
+```
+
+---
+
+### Inbox 사용법
+
+**1. `@IdempotentConsumer` 적용**
+
+Kafka `@KafkaListener` 메서드에 어노테이션을 붙입니다. `value`에는 토픽명 또는 컨슈머 그룹명을 입력합니다.
+
+```java
+@Service
+@RequiredArgsConstructor
+public class OrderEventConsumer {
+
+    private final PaymentService paymentService;
+
+    @KafkaListener(topics = "order-created", groupId = "payment-service")
+    @IdempotentConsumer("order-created")   // value = 메시지 그룹 구분자
+    public void handleOrderCreated(ConsumerRecord<String, String> record) {
+        // message_id 헤더가 있으면 자동으로 중복 체크
+        // 이미 처리된 메시지면 이 메서드는 실행되지 않음
+        paymentService.processPayment(record.value());
+    }
+}
+```
+
+> `message_id` 헤더는 Outbox 패턴으로 발행된 메시지에 자동으로 포함됩니다.
+> 외부에서 수신하는 메시지도 헤더에 `message_id`를 포함하면 동일하게 멱등성이 보장됩니다.
+
+**2. DB 마이그레이션**
+
+소비자 서비스의 DB에 `p_inbox` 테이블이 필요합니다.
+
+```sql
+CREATE TABLE p_inbox (
+    id              UUID PRIMARY KEY,
+    message_id      UUID         NOT NULL,
+    message_group   VARCHAR(100),
+    processed_at    TIMESTAMP,
+    created_at      TIMESTAMP    NOT NULL,
+    updated_at      TIMESTAMP    NOT NULL,
+    CONSTRAINT uk_inbox_message_id_group UNIQUE (message_id, message_group)
+);
+
+CREATE INDEX idx_inbox_message_group ON p_inbox (message_group);
+CREATE INDEX idx_inbox_processed_at  ON p_inbox (processed_at);
+```
+
+---
+
+## 6. 페이지네이션
+
+두 가지 방식을 지원합니다. `EventConfig`를 import하면 `ArgumentResolver`가 자동 등록되어 컨트롤러 파라미터로 바로 사용할 수 있습니다.
+
+### Offset 기반 페이지네이션
+
+전체 데이터 수와 페이지 번호가 필요한 일반적인 목록 조회에 사용합니다.
+
+**허용 사이즈:** `10`, `30`, `50` (그 외 값은 기본값 `10`으로 대체)
+
+```java
+// Controller
+@GetMapping("/orders")
+public ApiResponse<CommonPageResponse<OrderResponse>> getOrders(CommonPageRequest pageRequest) {
+    Page<Order> page = orderRepository.findAll(pageRequest.toPageable());
+    return ApiResponse.success(CommonPageResponse.of(page, OrderResponse::from));
+}
+```
+
+```
+GET /orders?page=0&size=10
+GET /orders?page=1&size=30&sort=createdAt,desc   // 정렬 포함
+```
+
+**응답 포맷**
+
+```json
+{
+  "content": [...],
+  "page": 0,
+  "size": 10,
+  "totalElements": 253,
+  "totalPages": 26,
+  "first": true,
+  "last": false
+}
+```
+
+**정렬을 포함한 Pageable 생성**
+
+```java
+Pageable pageable = pageRequest.toPageable(Sort.by(Sort.Direction.DESC, "createdAt"));
+```
+
+---
+
+### Cursor 기반 페이지네이션
+
+무한 스크롤, 피드처럼 전체 데이터 수가 필요 없고 성능이 중요한 경우에 사용합니다. `cursor`가 없으면 첫 페이지입니다.
+
+```java
+// Controller
+@GetMapping("/feeds")
+public ApiResponse<CommonCursorResponse<FeedResponse>> getFeeds(CommonCursorRequest cursorRequest) {
+    // size + 1개를 조회해서 다음 페이지 존재 여부를 판단
+    List<Feed> feeds = feedRepository.findByCursor(
+            cursorRequest.getCursor(),
+            cursorRequest.getSize() + 1
+    );
+    return ApiResponse.success(
+            CommonCursorResponse.of(feeds, cursorRequest.getSize(), FeedResponse::from, Feed::getCursorKey)
+    );
+}
+```
+
+```
+GET /feeds?size=10              // 첫 페이지
+GET /feeds?cursor=xxx&size=10   // 다음 페이지
+```
+
+**응답 포맷**
+
+```json
+{
+  "content": [...],
+  "nextCursor": "eyJpZCI6MTIzfQ",
+  "hasNext": true
+}
+```
+
+`nextCursor`가 `null`이면 마지막 페이지입니다.
+
+---
+
+### 페이지네이션 방식 선택 기준
+
+| | Offset | Cursor |
+|---|---|---|
+| 전체 페이지 수 표시 | 가능 | 불가 |
+| 특정 페이지 이동 | 가능 | 불가 |
+| 대용량 데이터 성능 | 느려짐 (OFFSET 비용) | 일정 (인덱스 활용) |
+| 적합한 UX | 페이지네이션 버튼 | 무한 스크롤 |
+
+---
+
+## 7. MDC 요청 추적
+
+`MdcLoggingFilter`가 자동 등록됩니다. 모든 요청에 `traceId`, `uri`, `method`가 MDC에 주입되어 로그에서 요청 단위로 추적할 수 있습니다.
+
+**logback 설정 예시**
+
+```xml
+<pattern>[%X{traceId}] [%X{method} %X{uri}] %d{HH:mm:ss} %-5level %logger - %msg%n</pattern>
+```
+
+**traceId 전달**
+
+외부에서 `X-Trace-Id` 헤더를 넘기면 해당 값을 traceId로 사용합니다. 없으면 자동 생성됩니다.
+
+```
+X-Trace-Id: a3f2bc91-7e4d
+```
+
+**비동기 처리**
+
+`@Async` 메서드에서도 traceId가 유지됩니다. `EventConfig`에 등록된 스레드 풀이 `MdcTaskDecorator`를 통해 부모 스레드의 MDC 컨텍스트를 자식 스레드에 복사합니다.
+
+---
+
+## 8. 버전 히스토리
 
 | 버전 | 변경 내용 |
 |------|-----------|
-| 1.0.0 | 최초 릴리즈 |
+| 1.0.0 | 최초 릴리즈: 예외 처리, 공통 응답, Outbox/Inbox, 페이지네이션, MDC |

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
     `maven-publish`
 }
 
-group = "com.nine-oogle"
+group = "com.goggles"
 version = "1.0.0"
 
 java {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,7 +18,7 @@ repositories {
     mavenCentral()
 }
 
-val springBootVersion = "3.5.1"
+val springBootVersion = "3.5.13"
 val lombokVersion = "1.18.34"
 val querydslVersion = "5.1.0"
 
@@ -51,6 +51,12 @@ dependencies {
     compileOnly("org.springframework.boot:spring-boot-autoconfigure")
     compileOnly("jakarta.validation:jakarta.validation-api")
     compileOnly("jakarta.servlet:jakarta.servlet-api")
+
+    // ── Spring Security (선택적 — 소비자가 Security 없으면 관련 설정 비활성) ──
+    compileOnly("org.springframework.boot:spring-boot-starter-security")
+
+    // ── AOP / AspectJ (InboxAdvice @Aspect 용) ───────────────────────────────
+    compileOnly("org.springframework.boot:spring-boot-starter-aop")
 
     // ── Jackson (ApiResponse JSON 직렬화) ────────────────────────────────────
     // api → 소비자도 이 타입을 직접 쓰므로 transitive 허용

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -73,6 +73,7 @@ dependencies {
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.springframework.boot:spring-boot-starter-web")
     testImplementation("org.springframework.boot:spring-boot-starter-data-jpa")
+    testImplementation("org.springframework.boot:spring-boot-starter-validation")
     testImplementation("org.springframework.kafka:spring-kafka")
     testRuntimeOnly("com.h2database:h2")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")

--- a/src/main/java/com/goggles/common/domain/BaseAudit.java
+++ b/src/main/java/com/goggles/common/domain/BaseAudit.java
@@ -1,0 +1,51 @@
+package com.goggles.common.domain;
+
+import com.querydsl.core.annotations.QuerySupertype;
+import jakarta.persistence.Access;
+import jakarta.persistence.AccessType;
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.util.UUID;
+
+/**
+ * 생성/수정 시각 + 작성자 정보까지 관리하는 기반 엔티티.
+ *
+ * <p>소비자 서비스에서 {@code AuditorAware<String>} 빈을 등록해야 합니다.
+ *
+ * <pre>{@code
+ * @Bean
+ * public AuditorAware<String> auditorAware() {
+ *     return () -> Optional.ofNullable(SecurityContextHolder.getContext())
+ *         .map(ctx -> ctx.getAuthentication().getName());
+ * }
+ * }</pre>
+ */
+@Getter
+@QuerySupertype
+@MappedSuperclass
+@Access(AccessType.FIELD)
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseAudit extends BaseTime {
+
+    @CreatedBy
+    @Column(nullable = false, updatable = false, length = 100)
+    private UUID createdBy;
+
+    @LastModifiedBy
+    @Column(nullable = false, length = 100)
+    private UUID updatedBy;
+
+    @Column(length = 100)
+    private UUID deletedBy;
+
+    public void softDelete(UUID deletedBy) {
+        super.softDelete();
+        this.deletedBy = deletedBy;
+    }
+}

--- a/src/main/java/com/goggles/common/domain/BaseAudit.java
+++ b/src/main/java/com/goggles/common/domain/BaseAudit.java
@@ -16,13 +16,13 @@ import java.util.UUID;
 /**
  * 생성/수정 시각 + 작성자 정보까지 관리하는 기반 엔티티.
  *
- * <p>소비자 서비스에서 {@code AuditorAware<String>} 빈을 등록해야 합니다.
+ * <p>소비자 서비스에서 {@code AuditorAware<UUID>} 빈을 등록해야 합니다.
  *
  * <pre>{@code
  * @Bean
- * public AuditorAware<String> auditorAware() {
+ * public AuditorAware<UUID> auditorAware() {
  *     return () -> Optional.ofNullable(SecurityContextHolder.getContext())
- *         .map(ctx -> ctx.getAuthentication().getName());
+ *         .map(ctx -> UUID.fromString(ctx.getAuthentication().getName()));
  * }
  * }</pre>
  */

--- a/src/main/java/com/goggles/common/domain/BaseAudit.java
+++ b/src/main/java/com/goggles/common/domain/BaseAudit.java
@@ -1,11 +1,7 @@
 package com.goggles.common.domain;
 
 import com.querydsl.core.annotations.QuerySupertype;
-import jakarta.persistence.Access;
-import jakarta.persistence.AccessType;
-import jakarta.persistence.Column;
-import jakarta.persistence.EntityListeners;
-import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.*;
 import lombok.Getter;
 import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.LastModifiedBy;
@@ -33,19 +29,19 @@ import java.util.UUID;
 @EntityListeners(AuditingEntityListener.class)
 public abstract class BaseAudit extends BaseTime {
 
-    @CreatedBy
-    @Column(nullable = false, updatable = false, length = 100)
-    private UUID createdBy;
+	@CreatedBy
+	@Column(nullable = false, updatable = false, length = 100)
+	private UUID createdBy;
 
-    @LastModifiedBy
-    @Column(nullable = false, length = 100)
-    private UUID updatedBy;
+	@LastModifiedBy
+	@Column(nullable = false, length = 100)
+	private UUID updatedBy;
 
-    @Column(length = 100)
-    private UUID deletedBy;
+	@Column(length = 100)
+	private UUID deletedBy;
 
-    public void softDelete(UUID deletedBy) {
-        super.softDelete();
-        this.deletedBy = deletedBy;
-    }
+	public void softDelete(UUID deletedBy) {
+		super.softDelete();
+		this.deletedBy = deletedBy;
+	}
 }

--- a/src/main/java/com/goggles/common/domain/BaseTime.java
+++ b/src/main/java/com/goggles/common/domain/BaseTime.java
@@ -1,0 +1,52 @@
+package com.goggles.common.domain;
+
+import com.querydsl.core.annotations.QuerySupertype;
+import jakarta.persistence.Access;
+import jakarta.persistence.AccessType;
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+/**
+ * 생성/수정 시각만 관리하는 기반 엔티티.
+ *
+ * <p>소비자 서비스에서 반드시 {@code @EnableJpaAuditing} 을 선언해야 합니다.
+ *
+ * <pre>{@code
+ * @EnableJpaAuditing
+ * @SpringBootApplication
+ * public class MyServiceApplication { ... }
+ * }</pre>
+ */
+@Getter
+@QuerySupertype
+@MappedSuperclass
+@Access(AccessType.FIELD)
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTime {
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+
+    @Column
+    private LocalDateTime deletedAt;
+
+    public boolean isDeleted() {
+        return deletedAt != null;
+    }
+
+    public void softDelete() {
+        this.deletedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/goggles/common/domain/BaseTime.java
+++ b/src/main/java/com/goggles/common/domain/BaseTime.java
@@ -1,11 +1,7 @@
 package com.goggles.common.domain;
 
 import com.querydsl.core.annotations.QuerySupertype;
-import jakarta.persistence.Access;
-import jakarta.persistence.AccessType;
-import jakarta.persistence.Column;
-import jakarta.persistence.EntityListeners;
-import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.*;
 import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
@@ -31,22 +27,22 @@ import java.time.LocalDateTime;
 @EntityListeners(AuditingEntityListener.class)
 public abstract class BaseTime {
 
-    @CreatedDate
-    @Column(nullable = false, updatable = false)
-    private LocalDateTime createdAt;
+	@CreatedDate
+	@Column(nullable = false, updatable = false)
+	private LocalDateTime createdAt;
 
-    @LastModifiedDate
-    @Column(nullable = false)
-    private LocalDateTime updatedAt;
+	@LastModifiedDate
+	@Column(nullable = false)
+	private LocalDateTime updatedAt;
 
-    @Column
-    private LocalDateTime deletedAt;
+	@Column
+	private LocalDateTime deletedAt;
 
-    public boolean isDeleted() {
-        return deletedAt != null;
-    }
+	public boolean isDeleted() {
+		return deletedAt != null;
+	}
 
-    public void softDelete() {
-        this.deletedAt = LocalDateTime.now();
-    }
+	public void softDelete() {
+		this.deletedAt = LocalDateTime.now();
+	}
 }

--- a/src/main/java/com/goggles/common/domain/Inbox.java
+++ b/src/main/java/com/goggles/common/domain/Inbox.java
@@ -12,13 +12,10 @@ import java.util.UUID;
 @Entity
 @Getter
 @Builder
-@Table(name = "p_inbox",
-		uniqueConstraints = @UniqueConstraint(name = "uk_inbox_message_id_group", columnNames = {"messageId", "messageGroup"}),
-		indexes = {
-				@Index(name = "idx_inbox_message_group", columnList = "messageGroup"),
-				@Index(name = "idx_inbox_processed_at", columnList = "processedAt")
-		}
-)
+@Table(name = "p_inbox", uniqueConstraints = @UniqueConstraint(name = "uk_inbox_message_id_group", columnNames = {
+		"messageId", "messageGroup"}), indexes = {
+		@Index(name = "idx_inbox_message_group", columnList = "messageGroup"),
+		@Index(name = "idx_inbox_processed_at", columnList = "processedAt")})
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Access(AccessType.FIELD)

--- a/src/main/java/com/goggles/common/domain/Inbox.java
+++ b/src/main/java/com/goggles/common/domain/Inbox.java
@@ -1,0 +1,42 @@
+package com.goggles.common.domain;
+
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Getter
+@Builder
+@Table(name = "p_inbox",
+		uniqueConstraints = @UniqueConstraint(name = "uk_inbox_message_id_group", columnNames = {"messageId", "messageGroup"}),
+		indexes = {
+				@Index(name = "idx_inbox_message_group", columnList = "messageGroup"),
+				@Index(name = "idx_inbox_processed_at", columnList = "processedAt")
+		}
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Access(AccessType.FIELD)
+@EntityListeners(AuditingEntityListener.class)
+public class Inbox extends BaseTime {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.UUID)
+	@Column(columnDefinition = "uuid")
+	private UUID id;
+
+	@Column(columnDefinition = "uuid", nullable = false)
+	private UUID messageId; // = 생산자의 eventId
+
+	@Column(length = 100)
+	private String messageGroup; // topic 또는 consumer group
+
+	@CreatedDate
+	@Column(updatable = false)
+	private LocalDateTime processedAt;
+}

--- a/src/main/java/com/goggles/common/domain/InboxRepository.java
+++ b/src/main/java/com/goggles/common/domain/InboxRepository.java
@@ -1,0 +1,12 @@
+package com.goggles.common.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public interface InboxRepository extends JpaRepository<Inbox, UUID> {
+	boolean existsByMessageIdAndMessageGroup(UUID messageId, String messageGroup);
+
+	long deleteAllByCreatedAtBefore(LocalDateTime localDateTime);
+}

--- a/src/main/java/com/goggles/common/domain/Outbox.java
+++ b/src/main/java/com/goggles/common/domain/Outbox.java
@@ -15,7 +15,7 @@ import java.util.UUID;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Access(AccessType.FIELD)
 @EntityListeners(AuditingEntityListener.class)
-public class Outbox  extends BaseTime {
+public class Outbox extends BaseTime {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.UUID)

--- a/src/main/java/com/goggles/common/domain/Outbox.java
+++ b/src/main/java/com/goggles/common/domain/Outbox.java
@@ -1,0 +1,58 @@
+package com.goggles.common.domain;
+
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.util.UUID;
+
+@Entity
+@Getter
+@Builder
+@Table(name = "p_outbox", indexes = @Index(name = "idx_outbox_status", columnList = "status"))
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Access(AccessType.FIELD)
+@EntityListeners(AuditingEntityListener.class)
+public class Outbox  extends BaseTime {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.UUID)
+	@Column(columnDefinition = "uuid")
+	private UUID id;
+
+	@Column(length = 64, nullable = false, unique = true)
+	private String correlationId;
+
+	@Column(length = 50, nullable = false)
+	private String domainType;
+
+	@Column(length = 100, nullable = false)
+	private String eventType;
+
+	@Column(columnDefinition = "text")
+	private String payload;
+
+	@Builder.Default
+	@Enumerated(EnumType.STRING)
+	@Column(length = 20, nullable = false)
+	private OutboxStatus status = OutboxStatus.PENDING;
+
+	@Builder.Default
+	private int retryCount = 0;
+
+	public void processing() {
+		this.status = OutboxStatus.PROCESSING;
+	}
+
+	public void complete() {
+		this.status = OutboxStatus.PROCESSED;
+	}
+
+	public void fail() {
+		this.status = OutboxStatus.FAILED;
+		this.retryCount++;
+	}
+
+}

--- a/src/main/java/com/goggles/common/domain/OutboxRepository.java
+++ b/src/main/java/com/goggles/common/domain/OutboxRepository.java
@@ -1,15 +1,18 @@
 package com.goggles.common.domain;
 
+import org.springframework.data.jpa.repository.JpaRepository;
+
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
-import org.springframework.data.jpa.repository.JpaRepository;
-
 public interface OutboxRepository extends JpaRepository<Outbox, UUID> {
-  List<Outbox> findByStatusInAndRetryCountLessThan(List<OutboxStatus> statuses, int limit);
-  List<Outbox> findByStatusAndUpdatedAtBefore(OutboxStatus status, LocalDateTime threshold);
-  Optional<Outbox> findByCorrelationId(String correlationId);
-  boolean existsByCorrelationId(String correlationId);
+	List<Outbox> findByStatusInAndRetryCountLessThan(List<OutboxStatus> statuses, int limit);
+
+	List<Outbox> findByStatusAndUpdatedAtBefore(OutboxStatus status, LocalDateTime threshold);
+
+	Optional<Outbox> findByCorrelationId(String correlationId);
+
+	boolean existsByCorrelationId(String correlationId);
 }

--- a/src/main/java/com/goggles/common/domain/OutboxRepository.java
+++ b/src/main/java/com/goggles/common/domain/OutboxRepository.java
@@ -1,0 +1,15 @@
+package com.goggles.common.domain;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OutboxRepository extends JpaRepository<Outbox, UUID> {
+  List<Outbox> findByStatusInAndRetryCountLessThan(List<OutboxStatus> statuses, int limit);
+  List<Outbox> findByStatusAndUpdatedAtBefore(OutboxStatus status, LocalDateTime threshold);
+  Optional<Outbox> findByCorrelationId(String correlationId);
+  boolean existsByCorrelationId(String correlationId);
+}

--- a/src/main/java/com/goggles/common/domain/OutboxStatus.java
+++ b/src/main/java/com/goggles/common/domain/OutboxStatus.java
@@ -1,8 +1,5 @@
 package com.goggles.common.domain;
 
 public enum OutboxStatus {
-  PENDING,
-  PROCESSING,
-  PROCESSED,
-  FAILED
+	PENDING, PROCESSING, PROCESSED, FAILED
 }

--- a/src/main/java/com/goggles/common/domain/OutboxStatus.java
+++ b/src/main/java/com/goggles/common/domain/OutboxStatus.java
@@ -1,0 +1,8 @@
+package com.goggles.common.domain;
+
+public enum OutboxStatus {
+  PENDING,
+  PROCESSING,
+  PROCESSED,
+  FAILED
+}

--- a/src/main/java/com/goggles/common/event/Events.java
+++ b/src/main/java/com/goggles/common/event/Events.java
@@ -1,0 +1,13 @@
+package com.goggles.common.event;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+
+@RequiredArgsConstructor
+public class Events {
+	private final ApplicationEventPublisher eventPublisher;
+
+	public void trigger(String correlationId, String domainType, String eventType, Object payload) {
+		eventPublisher.publishEvent(new OutboxEvent(correlationId, domainType, eventType, payload));
+	}
+}

--- a/src/main/java/com/goggles/common/event/OutboxEvent.java
+++ b/src/main/java/com/goggles/common/event/OutboxEvent.java
@@ -1,8 +1,4 @@
 package com.goggles.common.event;
 
-public record OutboxEvent(
-		String correlationId,
-		String domainType,
-		String eventType,
-		Object payload
-) {}
+public record OutboxEvent(String correlationId, String domainType, String eventType,
+						  Object payload) {}

--- a/src/main/java/com/goggles/common/event/OutboxEvent.java
+++ b/src/main/java/com/goggles/common/event/OutboxEvent.java
@@ -1,0 +1,8 @@
+package com.goggles.common.event;
+
+public record OutboxEvent(
+		String correlationId,
+		String domainType,
+		String eventType,
+		Object payload
+) {}

--- a/src/main/java/com/goggles/common/event/OutboxEventListener.java
+++ b/src/main/java/com/goggles/common/event/OutboxEventListener.java
@@ -58,7 +58,7 @@ public class OutboxEventListener {
 				.ifPresent(outbox -> {
 					// Kafka 메시지에 ID 헤더 추가
 					ProducerRecord<String, Object> record =
-							new ProducerRecord<>(outbox.getEventType(), outbox.getPayload());
+							new ProducerRecord<>(outbox.getEventType(), null, outbox.getCorrelationId(), outbox.getPayload());
 					record.headers()
 							.add("message_id", outbox.getId()
 									.toString()

--- a/src/main/java/com/goggles/common/event/OutboxEventListener.java
+++ b/src/main/java/com/goggles/common/event/OutboxEventListener.java
@@ -1,0 +1,75 @@
+package com.goggles.common.event;
+
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.goggles.common.domain.Outbox;
+import com.goggles.common.domain.OutboxRepository;
+import com.goggles.common.domain.OutboxStatus;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.springframework.context.event.EventListener;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@RequiredArgsConstructor
+public class OutboxEventListener {
+
+	private final OutboxRepository outboxRepository;
+	private final KafkaTemplate<String, Object> kafkaTemplate;
+	private final ObjectMapper objectMapper;
+	private final OutboxStatusUpdater outboxStatusUpdater;
+
+
+
+	@EventListener
+	@Transactional(propagation = Propagation.REQUIRED)
+	public void recordOutbox(OutboxEvent event) {
+
+		if (outboxRepository.existsByCorrelationId(event.correlationId())) {
+			log.warn("이미 존재하는 correlationId 입니다.: {}", event.correlationId());
+			return;
+		}
+
+		try {
+			String jsonPayload = objectMapper.writeValueAsString(event.payload());
+
+			Outbox outbox = Outbox.builder()
+					.correlationId(event.correlationId())
+					.domainType(event.domainType())
+					.eventType(event.eventType())
+					.payload(jsonPayload)
+					.status(OutboxStatus.PENDING)
+					.build();
+			outboxRepository.save(outbox);
+		} catch (JsonProcessingException e) {
+			log.error("Output payload 직렬화 실패: {}", event.correlationId(), e);
+		}
+	}
+
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)
+	public void publish(OutboxEvent event) {
+		outboxRepository.findByCorrelationId(event.correlationId())
+				.ifPresent(outbox -> {
+					// Kafka 메시지에 ID 헤더 추가
+					ProducerRecord<String, Object> record =
+							new ProducerRecord<>(outbox.getEventType(), outbox.getPayload());
+					record.headers()
+							.add("message_id", outbox.getId()
+									.toString()
+									.getBytes());
+
+					kafkaTemplate.send(record)
+							.whenComplete((result, e) -> {
+								if (e == null) outboxStatusUpdater.handleSuccess(event.correlationId());
+								else outboxStatusUpdater.handleFailure(event, e);
+							});
+				});
+	}
+
+}

--- a/src/main/java/com/goggles/common/event/OutboxEventListener.java
+++ b/src/main/java/com/goggles/common/event/OutboxEventListener.java
@@ -26,7 +26,6 @@ public class OutboxEventListener {
 	private final OutboxStatusUpdater outboxStatusUpdater;
 
 
-
 	@EventListener
 	@Transactional(propagation = Propagation.REQUIRED)
 	public void recordOutbox(OutboxEvent event) {
@@ -58,7 +57,8 @@ public class OutboxEventListener {
 				.ifPresent(outbox -> {
 					// Kafka 메시지에 ID 헤더 추가
 					ProducerRecord<String, Object> record =
-							new ProducerRecord<>(outbox.getEventType(), null, outbox.getCorrelationId(), outbox.getPayload());
+							new ProducerRecord<>(outbox.getEventType(), null,
+									outbox.getCorrelationId(), outbox.getPayload());
 					record.headers()
 							.add("message_id", outbox.getId()
 									.toString()
@@ -66,7 +66,8 @@ public class OutboxEventListener {
 
 					kafkaTemplate.send(record)
 							.whenComplete((result, e) -> {
-								if (e == null) outboxStatusUpdater.handleSuccess(event.correlationId());
+								if (e == null)
+									outboxStatusUpdater.handleSuccess(event.correlationId());
 								else outboxStatusUpdater.handleFailure(event, e);
 							});
 				});

--- a/src/main/java/com/goggles/common/event/OutboxStatusUpdater.java
+++ b/src/main/java/com/goggles/common/event/OutboxStatusUpdater.java
@@ -1,0 +1,73 @@
+package com.goggles.common.event;
+
+import com.goggles.common.domain.OutboxRepository;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@RequiredArgsConstructor
+public class OutboxStatusUpdater {
+
+	private static final int MAX_RETRY = 3;
+	private final OutboxRepository outboxRepository;
+	private final KafkaTemplate<String, Object> kafkaTemplate;
+
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
+	public void handleSuccess(String correlationId) {
+		outboxRepository.findByCorrelationId(correlationId)
+				.ifPresent(outbox -> {
+					outbox.complete();
+					outboxRepository.save(outbox);
+					log.info("Outbox 메세지 전송 및 상태 완료 변경 성공: {}", correlationId);
+				});
+	}
+
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
+	public void handleFailure(OutboxEvent event, Throwable e) {
+		outboxRepository.findByCorrelationId(event.correlationId())
+				.ifPresent(outbox -> {
+					outbox.fail();
+					outboxRepository.saveAndFlush(outbox);
+
+					if (outbox.getRetryCount() >= MAX_RETRY) {
+						log.error("최대 재시도 횟수 초과(Total: {}). DLT로 격리합니다: {}", outbox.getRetryCount(),
+								event.correlationId());
+						sendToDlt(event, outbox.getPayload());
+					} else {
+						log.warn("메세지 전송 실패 (재시도 예정 {}/{}): {}", outbox.getRetryCount(), MAX_RETRY,
+								event.correlationId());
+					}
+				});
+	}
+
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
+	public void updateRelayStatus(UUID id, boolean isSuccess) {
+		outboxRepository.findById(id).ifPresent(outbox -> {
+			if (isSuccess) {
+				outbox.complete();
+				log.info("재전송 성공: {}", outbox.getCorrelationId());
+			} else {
+				outbox.fail();
+				log.warn("재전송 실패 (현재 횟수: {}): {}", outbox.getRetryCount(), outbox.getCorrelationId());
+			}
+			outboxRepository.saveAndFlush(outbox);
+		});
+	}
+
+	private void sendToDlt(OutboxEvent event, String payload) {
+		String dltTopic = event.eventType() + ".DLT";
+		try {
+			kafkaTemplate.send(dltTopic, payload)
+					.whenComplete((res, e) -> {
+						if (e != null) log.error("DLT 전송 실패: {}", event.correlationId(), e);
+						else log.info("DLT 전송 성공: {}", event.correlationId());
+					});
+		} catch (Exception e) {
+			log.error("DLT 전송 중 예외 발생: {}", event.correlationId(), e);
+		}
+	}
+}

--- a/src/main/java/com/goggles/common/event/OutboxStatusUpdater.java
+++ b/src/main/java/com/goggles/common/event/OutboxStatusUpdater.java
@@ -1,12 +1,13 @@
 package com.goggles.common.event;
 
 import com.goggles.common.domain.OutboxRepository;
-import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -37,7 +38,8 @@ public class OutboxStatusUpdater {
 						log.error("최대 재시도 횟수 초과(Total: {}). DLT로 격리합니다: {}", outbox.getRetryCount(),
 								event.correlationId());
 						sendToDlt(event, outbox.getPayload());
-					} else {
+					}
+					else {
 						log.warn("메세지 전송 실패 (재시도 예정 {}/{}): {}", outbox.getRetryCount(), MAX_RETRY,
 								event.correlationId());
 					}
@@ -46,16 +48,19 @@ public class OutboxStatusUpdater {
 
 	@Transactional(propagation = Propagation.REQUIRES_NEW)
 	public void updateRelayStatus(UUID id, boolean isSuccess) {
-		outboxRepository.findById(id).ifPresent(outbox -> {
-			if (isSuccess) {
-				outbox.complete();
-				log.info("재전송 성공: {}", outbox.getCorrelationId());
-			} else {
-				outbox.fail();
-				log.warn("재전송 실패 (현재 횟수: {}): {}", outbox.getRetryCount(), outbox.getCorrelationId());
-			}
-			outboxRepository.saveAndFlush(outbox);
-		});
+		outboxRepository.findById(id)
+				.ifPresent(outbox -> {
+					if (isSuccess) {
+						outbox.complete();
+						log.info("재전송 성공: {}", outbox.getCorrelationId());
+					}
+					else {
+						outbox.fail();
+						log.warn("재전송 실패 (현재 횟수: {}): {}", outbox.getRetryCount(),
+								outbox.getCorrelationId());
+					}
+					outboxRepository.saveAndFlush(outbox);
+				});
 	}
 
 	private void sendToDlt(OutboxEvent event, String payload) {

--- a/src/main/java/com/goggles/common/event/advice/InboxAdvice.java
+++ b/src/main/java/com/goggles/common/event/advice/InboxAdvice.java
@@ -21,65 +21,68 @@ import java.util.UUID;
 @Aspect
 @RequiredArgsConstructor
 public class InboxAdvice {
-    private final InboxRepository inboxRepository;
+	private final InboxRepository inboxRepository;
 
-    @Around("@annotation(idempotentConsumer)")
-    @Transactional(rollbackFor = Exception.class)
-    public Object handle(ProceedingJoinPoint joinPoint, IdempotentConsumer idempotentConsumer) throws Throwable {
-        UUID messageId = extractMessageId(joinPoint.getArgs());
+	@Around("@annotation(idempotentConsumer)")
+	@Transactional(rollbackFor = Exception.class)
+	public Object handle(ProceedingJoinPoint joinPoint, IdempotentConsumer idempotentConsumer)
+			throws Throwable {
+		UUID messageId = extractMessageId(joinPoint.getArgs());
 
-        if (messageId == null) {
-            log.warn("Message ID가 없는 메시지입니다. 멱등성 체크를 진행하지 않습니다.");
-            return joinPoint.proceed();
-        }
+		if (messageId == null) {
+			log.warn("Message ID가 없는 메시지입니다. 멱등성 체크를 진행하지 않습니다.");
+			return joinPoint.proceed();
+		}
 
-        try {
-            // 메서드 실행 성공 시 Inbox에 기록 (messageId는 Outbox에서 발행된 ID이며 동일하게 저장합니다.)
-            Inbox inbox = Inbox.builder()
-                    .messageId(messageId)
-                    .messageGroup(idempotentConsumer.value())
-                    .build();
+		try {
+			// 메서드 실행 성공 시 Inbox에 기록 (messageId는 Outbox에서 발행된 ID이며 동일하게 저장합니다.)
+			Inbox inbox = Inbox.builder()
+					.messageId(messageId)
+					.messageGroup(idempotentConsumer.value())
+					.build();
 
-            inboxRepository.saveAndFlush(inbox);
-            log.debug("Inbox 기록 성공: {}", messageId);
+			inboxRepository.saveAndFlush(inbox);
+			log.debug("Inbox 기록 성공: {}", messageId);
 
-        } catch (DataIntegrityViolationException e) {
-            log.info("이미 처리 중이거나 완료된 중복 메시지입니다: {}", messageId);
-            return null;
-        }
+		} catch (DataIntegrityViolationException e) {
+			log.info("이미 처리 중이거나 완료된 중복 메시지입니다: {}", messageId);
+			return null;
+		}
 
-        try {
-            return joinPoint.proceed();
-        } catch (Throwable throwable) {
-            log.error("메세지 수신 실패, Inbox 기록을 롤백합니다: {}", messageId);
-            throw throwable;
-        }
-    }
+		try {
+			return joinPoint.proceed();
+		} catch (Throwable throwable) {
+			log.error("메세지 수신 실패, Inbox 기록을 롤백합니다: {}", messageId);
+			throw throwable;
+		}
+	}
 
-    private UUID extractMessageId(Object[] args) {
-        for (Object arg : args) {
-            // Kafka 리스너에서 ConsumerRecord<K, V>를 파라미터로 받을 경우
-            if (arg instanceof ConsumerRecord<?, ?> record) {
-                Header header = record.headers().lastHeader("message_id");
-                if (header != null) return parseUuid(header.value());
-            }
+	private UUID extractMessageId(Object[] args) {
+		for (Object arg : args) {
+			// Kafka 리스너에서 ConsumerRecord<K, V>를 파라미터로 받을 경우
+			if (arg instanceof ConsumerRecord<?, ?> record) {
+				Header header = record.headers()
+						.lastHeader("message_id");
+				if (header != null) return parseUuid(header.value());
+			}
 
-            // Spring Messaging Message 객체인 경우
-            if (arg instanceof Message<?> message) {
-                Object header = message.getHeaders().get("message_id");
-                if (header instanceof byte[] bytes) return parseUuid(bytes);
-                if (header instanceof String str) return UUID.fromString(str);
-            }
-        }
-        return null;
-    }
+			// Spring Messaging Message 객체인 경우
+			if (arg instanceof Message<?> message) {
+				Object header = message.getHeaders()
+						.get("message_id");
+				if (header instanceof byte[] bytes) return parseUuid(bytes);
+				if (header instanceof String str) return UUID.fromString(str);
+			}
+		}
+		return null;
+	}
 
-    private UUID parseUuid(byte[] value) {
-        try {
-            return UUID.fromString(new String(value, StandardCharsets.UTF_8));
-        } catch (Exception e) {
-            log.error("메시지 ID 형식이 유효하지 않습니다:{}", value, e);
-            return null;
-        }
-    }
+	private UUID parseUuid(byte[] value) {
+		try {
+			return UUID.fromString(new String(value, StandardCharsets.UTF_8));
+		} catch (Exception e) {
+			log.error("메시지 ID 형식이 유효하지 않습니다:{}", value, e);
+			return null;
+		}
+	}
 }

--- a/src/main/java/com/goggles/common/event/advice/InboxAdvice.java
+++ b/src/main/java/com/goggles/common/event/advice/InboxAdvice.java
@@ -1,0 +1,85 @@
+package com.goggles.common.event.advice;
+
+import com.goggles.common.domain.Inbox;
+import com.goggles.common.domain.InboxRepository;
+import com.goggles.common.event.annotation.IdempotentConsumer;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.header.Header;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.messaging.Message;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+
+@Slf4j
+@Aspect
+@RequiredArgsConstructor
+public class InboxAdvice {
+    private final InboxRepository inboxRepository;
+
+    @Around("@annotation(idempotentConsumer)")
+    @Transactional(rollbackFor = Exception.class)
+    public Object handle(ProceedingJoinPoint joinPoint, IdempotentConsumer idempotentConsumer) throws Throwable {
+        UUID messageId = extractMessageId(joinPoint.getArgs());
+
+        if (messageId == null) {
+            log.warn("Message ID가 없는 메시지입니다. 멱등성 체크를 진행하지 않습니다.");
+            return joinPoint.proceed();
+        }
+
+        try {
+            // 메서드 실행 성공 시 Inbox에 기록 (messageId는 Outbox에서 발행된 ID이며 동일하게 저장합니다.)
+            Inbox inbox = Inbox.builder()
+                    .messageId(messageId)
+                    .messageGroup(idempotentConsumer.value())
+                    .build();
+
+            inboxRepository.saveAndFlush(inbox);
+            log.debug("Inbox 기록 성공: {}", messageId);
+
+        } catch (DataIntegrityViolationException e) {
+            log.info("이미 처리 중이거나 완료된 중복 메시지입니다: {}", messageId);
+            return null;
+        }
+
+        try {
+            return joinPoint.proceed();
+        } catch (Throwable throwable) {
+            log.error("메세지 수신 실패, Inbox 기록을 롤백합니다: {}", messageId);
+            throw throwable;
+        }
+    }
+
+    private UUID extractMessageId(Object[] args) {
+        for (Object arg : args) {
+            // Kafka 리스너에서 ConsumerRecord<K, V>를 파라미터로 받을 경우
+            if (arg instanceof ConsumerRecord<?, ?> record) {
+                Header header = record.headers().lastHeader("message_id");
+                if (header != null) return parseUuid(header.value());
+            }
+
+            // Spring Messaging Message 객체인 경우
+            if (arg instanceof Message<?> message) {
+                Object header = message.getHeaders().get("message_id");
+                if (header instanceof byte[] bytes) return parseUuid(bytes);
+                if (header instanceof String str) return UUID.fromString(str);
+            }
+        }
+        return null;
+    }
+
+    private UUID parseUuid(byte[] value) {
+        try {
+            return UUID.fromString(new String(value, StandardCharsets.UTF_8));
+        } catch (Exception e) {
+            log.error("메시지 ID 형식이 유효하지 않습니다:{}", value, e);
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/goggles/common/event/annotation/IdempotentConsumer.java
+++ b/src/main/java/com/goggles/common/event/annotation/IdempotentConsumer.java
@@ -1,0 +1,12 @@
+package com.goggles.common.event.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface IdempotentConsumer {
+    String value(); // 메세지 그룹
+}

--- a/src/main/java/com/goggles/common/event/annotation/IdempotentConsumer.java
+++ b/src/main/java/com/goggles/common/event/annotation/IdempotentConsumer.java
@@ -8,5 +8,5 @@ import java.lang.annotation.Target;
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface IdempotentConsumer {
-    String value(); // 메세지 그룹
+	String value(); // 메세지 그룹
 }

--- a/src/main/java/com/goggles/common/event/scheduler/InboxCleanupScheduler.java
+++ b/src/main/java/com/goggles/common/event/scheduler/InboxCleanupScheduler.java
@@ -1,0 +1,24 @@
+package com.goggles.common.event.scheduler;
+
+import com.goggles.common.domain.InboxRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Slf4j
+@RequiredArgsConstructor
+public class InboxCleanupScheduler {
+    private final InboxRepository inboxRepository;
+
+    @Transactional
+    @Scheduled(cron = "0 0 3 * * *") // 매일 새벽 3시에 정리 작업 진행
+    public void cleanupOldMessage() {
+        // 7일 이전 목록 삭제
+        long count = inboxRepository.deleteAllByCreatedAtBefore(LocalDateTime.now().minusDays(7));
+
+        log.info("7일 경과 Inbox 내역 삭제: {}건 삭제됨", count);
+    }
+}

--- a/src/main/java/com/goggles/common/event/scheduler/InboxCleanupScheduler.java
+++ b/src/main/java/com/goggles/common/event/scheduler/InboxCleanupScheduler.java
@@ -11,14 +11,15 @@ import java.time.LocalDateTime;
 @Slf4j
 @RequiredArgsConstructor
 public class InboxCleanupScheduler {
-    private final InboxRepository inboxRepository;
+	private final InboxRepository inboxRepository;
 
-    @Transactional
-    @Scheduled(cron = "0 0 3 * * *") // 매일 새벽 3시에 정리 작업 진행
-    public void cleanupOldMessage() {
-        // 7일 이전 목록 삭제
-        long count = inboxRepository.deleteAllByCreatedAtBefore(LocalDateTime.now().minusDays(7));
+	@Transactional
+	@Scheduled(cron = "0 0 3 * * *") // 매일 새벽 3시에 정리 작업 진행
+	public void cleanupOldMessage() {
+		// 7일 이전 목록 삭제
+		long count = inboxRepository.deleteAllByCreatedAtBefore(LocalDateTime.now()
+				.minusDays(7));
 
-        log.info("7일 경과 Inbox 내역 삭제: {}건 삭제됨", count);
-    }
+		log.info("7일 경과 Inbox 내역 삭제: {}건 삭제됨", count);
+	}
 }

--- a/src/main/java/com/goggles/common/event/scheduler/OutboxRelayScheduler.java
+++ b/src/main/java/com/goggles/common/event/scheduler/OutboxRelayScheduler.java
@@ -5,16 +5,16 @@ import com.goggles.common.domain.Outbox;
 import com.goggles.common.domain.OutboxRepository;
 import com.goggles.common.domain.OutboxStatus;
 import com.goggles.common.event.OutboxStatusUpdater;
-
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -35,8 +35,10 @@ public class OutboxRelayScheduler {
 				List.of(OutboxStatus.PENDING, OutboxStatus.FAILED), MAX_RETRY));
 
 		// 서버 재시작 등으로 PROCESSING 상태가 일정 시간 이상 유지된 row 복구
-		List<Outbox> stuckTargets = outboxRepository.findByStatusAndUpdatedAtBefore(
-				OutboxStatus.PROCESSING, LocalDateTime.now().minusMinutes(PROCESSING_STUCK_MINUTES));
+		List<Outbox> stuckTargets =
+				outboxRepository.findByStatusAndUpdatedAtBefore(OutboxStatus.PROCESSING,
+						LocalDateTime.now()
+								.minusMinutes(PROCESSING_STUCK_MINUTES));
 		if (!stuckTargets.isEmpty()) {
 			log.warn("[Outbox] PROCESSING stuck 감지 {}건 — 재처리합니다", stuckTargets.size());
 			targets.addAll(stuckTargets);
@@ -53,8 +55,10 @@ public class OutboxRelayScheduler {
 
 			UUID id = outbox.getId();
 			try {
-				kafkaTemplate.send(outbox.getEventType(), outbox.getCorrelationId(), outbox.getPayload())
-						.whenComplete((result, e) -> outboxStatusUpdater.updateRelayStatus(id, e == null));
+				kafkaTemplate.send(outbox.getEventType(), outbox.getCorrelationId(),
+								outbox.getPayload())
+						.whenComplete((result, e) -> outboxStatusUpdater.updateRelayStatus(id,
+								e == null));
 			} catch (Exception e) {
 				outboxStatusUpdater.updateRelayStatus(id, false);
 				log.error("[Outbox] 재전송 실패 - outboxId={}", id, e);

--- a/src/main/java/com/goggles/common/event/scheduler/OutboxRelayScheduler.java
+++ b/src/main/java/com/goggles/common/event/scheduler/OutboxRelayScheduler.java
@@ -1,0 +1,64 @@
+package com.goggles.common.event.scheduler;
+
+
+import com.goggles.common.domain.Outbox;
+import com.goggles.common.domain.OutboxRepository;
+import com.goggles.common.domain.OutboxStatus;
+import com.goggles.common.event.OutboxStatusUpdater;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@RequiredArgsConstructor
+public class OutboxRelayScheduler {
+
+	private static final int MAX_RETRY = 3;
+	private static final int PROCESSING_STUCK_MINUTES = 5;
+
+	private final OutboxRepository outboxRepository;
+	private final KafkaTemplate<String, Object> kafkaTemplate;
+	private final OutboxStatusUpdater outboxStatusUpdater;
+
+	@Scheduled(fixedDelay = 10000)
+	@Transactional
+	public void relay() {
+		List<Outbox> targets = new ArrayList<>();
+		targets.addAll(outboxRepository.findByStatusInAndRetryCountLessThan(
+				List.of(OutboxStatus.PENDING, OutboxStatus.FAILED), MAX_RETRY));
+
+		// 서버 재시작 등으로 PROCESSING 상태가 일정 시간 이상 유지된 row 복구
+		List<Outbox> stuckTargets = outboxRepository.findByStatusAndUpdatedAtBefore(
+				OutboxStatus.PROCESSING, LocalDateTime.now().minusMinutes(PROCESSING_STUCK_MINUTES));
+		if (!stuckTargets.isEmpty()) {
+			log.warn("[Outbox] PROCESSING stuck 감지 {}건 — 재처리합니다", stuckTargets.size());
+			targets.addAll(stuckTargets);
+		}
+
+		if (targets.isEmpty()) return;
+
+		log.info("[Outbox] 재전송 대상 {}건", targets.size());
+
+		for (Outbox outbox : targets) {
+			// 다른 인스턴스가 같은 row를 집어가지 못하도록 PROCESSING으로 선점
+			outbox.processing();
+			outboxRepository.saveAndFlush(outbox);
+
+			UUID id = outbox.getId();
+			try {
+				kafkaTemplate.send(outbox.getEventType(), outbox.getPayload())
+						.whenComplete((result, e) -> outboxStatusUpdater.updateRelayStatus(id, e == null));
+			} catch (Exception e) {
+				outboxStatusUpdater.updateRelayStatus(id, false);
+				log.error("[Outbox] 재전송 실패 - outboxId={}", id, e);
+			}
+		}
+	}
+}

--- a/src/main/java/com/goggles/common/event/scheduler/OutboxRelayScheduler.java
+++ b/src/main/java/com/goggles/common/event/scheduler/OutboxRelayScheduler.java
@@ -53,7 +53,7 @@ public class OutboxRelayScheduler {
 
 			UUID id = outbox.getId();
 			try {
-				kafkaTemplate.send(outbox.getEventType(), outbox.getPayload())
+				kafkaTemplate.send(outbox.getEventType(), outbox.getCorrelationId(), outbox.getPayload())
 						.whenComplete((result, e) -> outboxStatusUpdater.updateRelayStatus(id, e == null));
 			} catch (Exception e) {
 				outboxStatusUpdater.updateRelayStatus(id, false);

--- a/src/main/java/com/goggles/common/exception/BadRequestException.java
+++ b/src/main/java/com/goggles/common/exception/BadRequestException.java
@@ -6,12 +6,12 @@ import org.springframework.http.HttpStatus;
 @Getter
 public class BadRequestException extends CustomException {
 
-    public BadRequestException(String message) {
-        super( message, HttpStatus.BAD_REQUEST);
-    }
+	public BadRequestException(String message) {
+		super(message, HttpStatus.BAD_REQUEST);
+	}
 
-    public BadRequestException(String field, String message) {
-        super(field, message, HttpStatus.BAD_REQUEST);
+	public BadRequestException(String field, String message) {
+		super(field, message, HttpStatus.BAD_REQUEST);
 
-    }
+	}
 }

--- a/src/main/java/com/goggles/common/exception/BadRequestException.java
+++ b/src/main/java/com/goggles/common/exception/BadRequestException.java
@@ -1,0 +1,17 @@
+package com.goggles.common.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class BadRequestException extends CustomException {
+
+    public BadRequestException(String message) {
+        super( message, HttpStatus.BAD_REQUEST);
+    }
+
+    public BadRequestException(String field, String message) {
+        super(field, message, HttpStatus.BAD_REQUEST);
+
+    }
+}

--- a/src/main/java/com/goggles/common/exception/ConflictException.java
+++ b/src/main/java/com/goggles/common/exception/ConflictException.java
@@ -1,0 +1,9 @@
+package com.goggles.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class ConflictException extends CustomException {
+    public ConflictException(String message) {
+        super(message, HttpStatus.CONFLICT);
+    }
+}

--- a/src/main/java/com/goggles/common/exception/ConflictException.java
+++ b/src/main/java/com/goggles/common/exception/ConflictException.java
@@ -3,7 +3,7 @@ package com.goggles.common.exception;
 import org.springframework.http.HttpStatus;
 
 public class ConflictException extends CustomException {
-    public ConflictException(String message) {
-        super(message, HttpStatus.CONFLICT);
-    }
+	public ConflictException(String message) {
+		super(message, HttpStatus.CONFLICT);
+	}
 }

--- a/src/main/java/com/goggles/common/exception/CustomException.java
+++ b/src/main/java/com/goggles/common/exception/CustomException.java
@@ -1,0 +1,23 @@
+package com.goggles.common.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class CustomException extends RuntimeException {
+
+    private final HttpStatus status;
+    private final String field;
+
+    public CustomException(String message, HttpStatus status) {
+        super(message);
+        this.status = (status != null) ? status : HttpStatus.INTERNAL_SERVER_ERROR;
+        this.field = null;
+    }
+
+    public CustomException(String field, String message, HttpStatus status) {
+        super(message);
+        this.status = (status != null) ? status : HttpStatus.INTERNAL_SERVER_ERROR;
+        this.field = field;
+    }
+}

--- a/src/main/java/com/goggles/common/exception/CustomException.java
+++ b/src/main/java/com/goggles/common/exception/CustomException.java
@@ -6,18 +6,18 @@ import org.springframework.http.HttpStatus;
 @Getter
 public class CustomException extends RuntimeException {
 
-    private final HttpStatus status;
-    private final String field;
+	private final HttpStatus status;
+	private final String field;
 
-    public CustomException(String message, HttpStatus status) {
-        super(message);
-        this.status = (status != null) ? status : HttpStatus.INTERNAL_SERVER_ERROR;
-        this.field = null;
-    }
+	public CustomException(String message, HttpStatus status) {
+		super(message);
+		this.status = (status != null) ? status : HttpStatus.INTERNAL_SERVER_ERROR;
+		this.field = null;
+	}
 
-    public CustomException(String field, String message, HttpStatus status) {
-        super(message);
-        this.status = (status != null) ? status : HttpStatus.INTERNAL_SERVER_ERROR;
-        this.field = field;
-    }
+	public CustomException(String field, String message, HttpStatus status) {
+		super(message);
+		this.status = (status != null) ? status : HttpStatus.INTERNAL_SERVER_ERROR;
+		this.field = field;
+	}
 }

--- a/src/main/java/com/goggles/common/exception/ForbiddenException.java
+++ b/src/main/java/com/goggles/common/exception/ForbiddenException.java
@@ -1,0 +1,12 @@
+package com.goggles.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class ForbiddenException extends CustomException {
+    public ForbiddenException() {
+        this("해당 작업에 대한 접근 권한이 없습니다.");
+    }
+    public ForbiddenException(String message) {
+        super(message, HttpStatus.FORBIDDEN);
+    }
+}

--- a/src/main/java/com/goggles/common/exception/ForbiddenException.java
+++ b/src/main/java/com/goggles/common/exception/ForbiddenException.java
@@ -3,10 +3,11 @@ package com.goggles.common.exception;
 import org.springframework.http.HttpStatus;
 
 public class ForbiddenException extends CustomException {
-    public ForbiddenException() {
-        this("해당 작업에 대한 접근 권한이 없습니다.");
-    }
-    public ForbiddenException(String message) {
-        super(message, HttpStatus.FORBIDDEN);
-    }
+	public ForbiddenException() {
+		this("해당 작업에 대한 접근 권한이 없습니다.");
+	}
+
+	public ForbiddenException(String message) {
+		super(message, HttpStatus.FORBIDDEN);
+	}
 }

--- a/src/main/java/com/goggles/common/exception/GlobalExceptionAdvice.java
+++ b/src/main/java/com/goggles/common/exception/GlobalExceptionAdvice.java
@@ -1,0 +1,111 @@
+package com.goggles.common.exception;
+
+import com.goggles.common.response.ErrorResponse;
+import jakarta.persistence.OptimisticLockException;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Slf4j
+@RestControllerAdvice("com.goggles")
+public class GlobalExceptionAdvice {
+
+	// 직접 정의한 CustomException 처리
+	@ExceptionHandler(CustomException.class)
+	public ResponseEntity<ErrorResponse> handleCustomException(CustomException e) {
+		// MDC에서 traceId를 가져와 로그에 명시적으로 출력
+		log.error("[TraceID: {}] Custom Exception: {}", MDC.get("traceId"), e.getMessage(), e);
+		return ResponseEntity.status(e.getStatus())
+				.body(ErrorResponse.of(e.getStatus(), e.getField(), e.getMessage()));
+	}
+
+	// Bean Validation (@Valid) 실패 시 처리
+	@ExceptionHandler(MethodArgumentNotValidException.class)
+	public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(
+			MethodArgumentNotValidException e) {
+		log.error("[TraceID: {}] Validation Exception: {} errors found", MDC.get("traceId"),
+				e.getBindingResult()
+						.getErrorCount(), e);
+
+		Map<String, String> errors = e.getBindingResult()
+				.getFieldErrors()
+				.stream()
+				.collect(Collectors.toMap(FieldError::getField,
+						fieldError -> fieldError.getDefaultMessage() != null ?
+								fieldError.getDefaultMessage() : "Invalid value",
+						(existing, replacement) -> existing + ", " + replacement));
+
+		return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+				.body(ErrorResponse.of(HttpStatus.BAD_REQUEST, errors));
+	}
+
+	/**
+	 * 제약 조건 위반 (@Validated) 처리 보강
+	 */
+	@ExceptionHandler(ConstraintViolationException.class)
+	public ResponseEntity<ErrorResponse> handleConstraintViolationException(
+			ConstraintViolationException e) {
+		log.error("[TraceID: {}] Constraint Violation: {}", MDC.get("traceId"), e.getMessage(), e);
+
+		// PathVariable 등에서 발생하는 에러를 필드 단위로 상세화
+		Map<String, String> errors = e.getConstraintViolations()
+				.stream()
+				.collect(Collectors.toMap(violation -> {
+							String path = violation.getPropertyPath()
+									.toString();
+							return path.substring(path.lastIndexOf('.') + 1);
+						}, ConstraintViolation::getMessage,
+						(existing, replacement) -> existing + ", " + replacement));
+
+		return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+				.body(ErrorResponse.of(HttpStatus.BAD_REQUEST, errors));
+	}
+
+	// HTTP 요청 바디(Body)가 없거나 읽을 수 없는 경우
+	@ExceptionHandler(HttpMessageNotReadableException.class)
+	public ResponseEntity<ErrorResponse> handleHttpMessageNotReadableException(
+			HttpMessageNotReadableException e) {
+		log.error("[TraceID: {}] Message Not Readable: {}", MDC.get("traceId"), e.getMessage(), e);
+		return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+				.body(ErrorResponse.of(HttpStatus.BAD_REQUEST, "요청 본문(Body)이 누락되었거나 형식이 잘못되었습니다."));
+	}
+
+	// 잘못된 인자 전달 (IllegalArgumentException)
+	@ExceptionHandler(IllegalArgumentException.class)
+	public ResponseEntity<ErrorResponse> handleIllegalArgumentException(
+			IllegalArgumentException e) {
+		log.error("[TraceID: {}] Illegal Argument: {}", MDC.get("traceId"), e.getMessage(), e);
+		return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+				.body(ErrorResponse.of(HttpStatus.BAD_REQUEST, "잘못된 요청 값: " + e.getMessage()));
+	}
+
+	// 낙관적 락 충돌 (동시성 제어 실패)
+	@ExceptionHandler({OptimisticLockException.class,
+			ObjectOptimisticLockingFailureException.class})
+	public ResponseEntity<ErrorResponse> handleOptimisticLockException(Exception e) {
+		log.error("[TraceID: {}] Optimistic Lock Error: {}", MDC.get("traceId"), e.getMessage(), e);
+		return ResponseEntity.status(HttpStatus.CONFLICT)
+				.body(ErrorResponse.of(HttpStatus.CONFLICT, "데이터 변경 중에 충돌이 발생했습니다. 다시 시도해주세요."));
+	}
+
+	// 그 외 정의되지 않은 모든 예외 처리
+	@ExceptionHandler(Exception.class)
+	public ResponseEntity<ErrorResponse> handleAllException(Exception e) {
+		// 시스템 예외는 추적을 위해 StackTrace 전체와 TraceID를 기록
+		log.error("[TraceID: {}] Unhandled Exception occurred", MDC.get("traceId"), e);
+		return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+				.body(ErrorResponse.of(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다."));
+	}
+}

--- a/src/main/java/com/goggles/common/exception/InternalServerException.java
+++ b/src/main/java/com/goggles/common/exception/InternalServerException.java
@@ -3,7 +3,7 @@ package com.goggles.common.exception;
 import org.springframework.http.HttpStatus;
 
 public class InternalServerException extends CustomException {
-    public InternalServerException(String message) {
-        super(message, HttpStatus.INTERNAL_SERVER_ERROR);
-    }
+	public InternalServerException(String message) {
+		super(message, HttpStatus.INTERNAL_SERVER_ERROR);
+	}
 }

--- a/src/main/java/com/goggles/common/exception/InternalServerException.java
+++ b/src/main/java/com/goggles/common/exception/InternalServerException.java
@@ -1,0 +1,9 @@
+package com.goggles.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class InternalServerException extends CustomException {
+    public InternalServerException(String message) {
+        super(message, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+}

--- a/src/main/java/com/goggles/common/exception/NotFoundException.java
+++ b/src/main/java/com/goggles/common/exception/NotFoundException.java
@@ -1,0 +1,9 @@
+package com.goggles.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class NotFoundException extends CustomException{
+    public NotFoundException(String message) {
+        super( message, HttpStatus.NOT_FOUND);
+    }
+}

--- a/src/main/java/com/goggles/common/exception/NotFoundException.java
+++ b/src/main/java/com/goggles/common/exception/NotFoundException.java
@@ -2,8 +2,8 @@ package com.goggles.common.exception;
 
 import org.springframework.http.HttpStatus;
 
-public class NotFoundException extends CustomException{
-    public NotFoundException(String message) {
-        super( message, HttpStatus.NOT_FOUND);
-    }
+public class NotFoundException extends CustomException {
+	public NotFoundException(String message) {
+		super(message, HttpStatus.NOT_FOUND);
+	}
 }

--- a/src/main/java/com/goggles/common/exception/UnAuthorizedException.java
+++ b/src/main/java/com/goggles/common/exception/UnAuthorizedException.java
@@ -1,0 +1,12 @@
+package com.goggles.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class UnAuthorizedException extends CustomException {
+    public UnAuthorizedException() {
+        this("로그인이 필요한 서비스입니다.");
+    }
+    public UnAuthorizedException(String message) {
+        super( message, HttpStatus.UNAUTHORIZED);
+    }
+}

--- a/src/main/java/com/goggles/common/exception/UnAuthorizedException.java
+++ b/src/main/java/com/goggles/common/exception/UnAuthorizedException.java
@@ -3,10 +3,11 @@ package com.goggles.common.exception;
 import org.springframework.http.HttpStatus;
 
 public class UnAuthorizedException extends CustomException {
-    public UnAuthorizedException() {
-        this("로그인이 필요한 서비스입니다.");
-    }
-    public UnAuthorizedException(String message) {
-        super( message, HttpStatus.UNAUTHORIZED);
-    }
+	public UnAuthorizedException() {
+		this("로그인이 필요한 서비스입니다.");
+	}
+
+	public UnAuthorizedException(String message) {
+		super(message, HttpStatus.UNAUTHORIZED);
+	}
 }

--- a/src/main/java/com/goggles/common/filter/MdcLoggingFilter.java
+++ b/src/main/java/com/goggles/common/filter/MdcLoggingFilter.java
@@ -1,0 +1,44 @@
+package com.goggles.common.filter;
+
+import jakarta.servlet.*;
+import jakarta.servlet.http.HttpServletRequest;
+import org.slf4j.MDC;
+
+import java.io.IOException;
+import java.util.UUID;
+
+/**
+ * MDC: Mapped Diagnostic Context(로그용 쓰레드 보관함)
+ * - 로그가 어떤 요청(Request)에 속해 있는지에 대한 부가 정보를 보관하는 쓰레드별 저장소
+ * - 내부적으로 ThreadLocal을 사용. 즉, 요청이 들어온 쓰레드 하나당 하나의 보관함이 배정된다.
+ */
+public class MdcLoggingFilter implements Filter {
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+
+        HttpServletRequest httpRequest = (HttpServletRequest) request;
+
+        // Trace ID 생성
+        String traceId = httpRequest.getHeader("X-Trace-Id");
+        if (traceId == null) {
+            traceId = UUID.randomUUID().toString().replace("-", "").substring(0, 16);
+        }
+        // URI 및 Method 정보 추출
+        String uri = httpRequest.getRequestURI();
+
+        String method = httpRequest.getMethod();
+
+        //  MDC에 주입
+        MDC.put("traceId", traceId);
+        MDC.put("uri", uri);
+        MDC.put("method", method);
+
+        try {
+            chain.doFilter(request, response);
+        } finally {
+            // 요청 종료 시 반드시 클리어
+            MDC.clear();
+        }
+    }
+}

--- a/src/main/java/com/goggles/common/filter/MdcLoggingFilter.java
+++ b/src/main/java/com/goggles/common/filter/MdcLoggingFilter.java
@@ -13,32 +13,35 @@ import java.util.UUID;
  * - 내부적으로 ThreadLocal을 사용. 즉, 요청이 들어온 쓰레드 하나당 하나의 보관함이 배정된다.
  */
 public class MdcLoggingFilter implements Filter {
-    @Override
-    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
-            throws IOException, ServletException {
+	@Override
+	public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+			throws IOException, ServletException {
 
-        HttpServletRequest httpRequest = (HttpServletRequest) request;
+		HttpServletRequest httpRequest = (HttpServletRequest) request;
 
-        // Trace ID 생성
-        String traceId = httpRequest.getHeader("X-Trace-Id");
-        if (traceId == null) {
-            traceId = UUID.randomUUID().toString().replace("-", "").substring(0, 16);
-        }
-        // URI 및 Method 정보 추출
-        String uri = httpRequest.getRequestURI();
+		// Trace ID 생성
+		String traceId = httpRequest.getHeader("X-Trace-Id");
+		if (traceId == null) {
+			traceId = UUID.randomUUID()
+					.toString()
+					.replace("-", "")
+					.substring(0, 16);
+		}
+		// URI 및 Method 정보 추출
+		String uri = httpRequest.getRequestURI();
 
-        String method = httpRequest.getMethod();
+		String method = httpRequest.getMethod();
 
-        //  MDC에 주입
-        MDC.put("traceId", traceId);
-        MDC.put("uri", uri);
-        MDC.put("method", method);
+		//  MDC에 주입
+		MDC.put("traceId", traceId);
+		MDC.put("uri", uri);
+		MDC.put("method", method);
 
-        try {
-            chain.doFilter(request, response);
-        } finally {
-            // 요청 종료 시 반드시 클리어
-            MDC.clear();
-        }
-    }
+		try {
+			chain.doFilter(request, response);
+		} finally {
+			// 요청 종료 시 반드시 클리어
+			MDC.clear();
+		}
+	}
 }

--- a/src/main/java/com/goggles/common/pagination/CommonCursorRequest.java
+++ b/src/main/java/com/goggles/common/pagination/CommonCursorRequest.java
@@ -20,19 +20,20 @@ import lombok.Getter;
 @Getter
 public class CommonCursorRequest {
 
-    private final String cursor; // null이면 첫 페이지
-    private final int size;
+	private final String cursor; // null이면 첫 페이지
+	private final int size;
 
-    private CommonCursorRequest(String cursor, int size) {
-        this.cursor = cursor;
-        this.size = CommonPageRequest.ALLOWED_SIZES.contains(size) ? size : CommonPageRequest.DEFAULT_SIZE;
-    }
+	private CommonCursorRequest(String cursor, int size) {
+		this.cursor = cursor;
+		this.size = CommonPageRequest.ALLOWED_SIZES.contains(size) ? size :
+				CommonPageRequest.DEFAULT_SIZE;
+	}
 
-    public static CommonCursorRequest of(String cursor, int size) {
-        return new CommonCursorRequest(cursor, size);
-    }
+	public static CommonCursorRequest of(String cursor, int size) {
+		return new CommonCursorRequest(cursor, size);
+	}
 
-    public boolean isFirst() {
-        return cursor == null;
-    }
+	public boolean isFirst() {
+		return cursor == null;
+	}
 }

--- a/src/main/java/com/goggles/common/pagination/CommonCursorRequest.java
+++ b/src/main/java/com/goggles/common/pagination/CommonCursorRequest.java
@@ -1,0 +1,38 @@
+package com.goggles.common.pagination;
+
+import lombok.Getter;
+
+/**
+ * 커서 기반 페이지 요청 DTO.
+ *
+ * <p>커서가 {@code null}이면 첫 페이지를 의미합니다.
+ * 허용되지 않은 size 값은 {@link CommonPageRequest#DEFAULT_SIZE}(10)으로 대체됩니다.
+ *
+ * <pre>{@code
+ * @GetMapping("/feeds")
+ * public ApiResponse<CursorResponse<FeedResponse>> list(CommonCursorRequest cursorRequest) {
+ *     return ApiResponse.success(feedService.list(cursorRequest));
+ * }
+ * }</pre>
+ *
+ * @see CommonCursorResponse
+ */
+@Getter
+public class CommonCursorRequest {
+
+    private final String cursor; // null이면 첫 페이지
+    private final int size;
+
+    private CommonCursorRequest(String cursor, int size) {
+        this.cursor = cursor;
+        this.size = CommonPageRequest.ALLOWED_SIZES.contains(size) ? size : CommonPageRequest.DEFAULT_SIZE;
+    }
+
+    public static CommonCursorRequest of(String cursor, int size) {
+        return new CommonCursorRequest(cursor, size);
+    }
+
+    public boolean isFirst() {
+        return cursor == null;
+    }
+}

--- a/src/main/java/com/goggles/common/pagination/CommonCursorRequestArgumentResolver.java
+++ b/src/main/java/com/goggles/common/pagination/CommonCursorRequestArgumentResolver.java
@@ -21,30 +21,28 @@ import org.springframework.web.method.support.ModelAndViewContainer;
  */
 public class CommonCursorRequestArgumentResolver implements HandlerMethodArgumentResolver {
 
-    @Override
-    public boolean supportsParameter(MethodParameter parameter) {
-        return CommonCursorRequest.class.equals(parameter.getParameterType());
-    }
+	@Override
+	public boolean supportsParameter(MethodParameter parameter) {
+		return CommonCursorRequest.class.equals(parameter.getParameterType());
+	}
 
-    @Override
-    public Object resolveArgument(MethodParameter parameter,
-                                  ModelAndViewContainer mavContainer,
-                                  NativeWebRequest webRequest,
-                                  WebDataBinderFactory binderFactory) {
-        String cursor = webRequest.getParameter("cursor");
-        String sizeParam = webRequest.getParameter("size");
+	@Override
+	public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+			NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+		String cursor = webRequest.getParameter("cursor");
+		String sizeParam = webRequest.getParameter("size");
 
-        int size = parseOrDefault(sizeParam);
+		int size = parseOrDefault(sizeParam);
 
-        return CommonCursorRequest.of(cursor, size);
-    }
+		return CommonCursorRequest.of(cursor, size);
+	}
 
-    private int parseOrDefault(String value) {
-        if (value == null) return CommonPageRequest.DEFAULT_SIZE;
-        try {
-            return Integer.parseInt(value);
-        } catch (NumberFormatException e) {
-            return CommonPageRequest.DEFAULT_SIZE;
-        }
-    }
+	private int parseOrDefault(String value) {
+		if (value == null) return CommonPageRequest.DEFAULT_SIZE;
+		try {
+			return Integer.parseInt(value);
+		} catch (NumberFormatException e) {
+			return CommonPageRequest.DEFAULT_SIZE;
+		}
+	}
 }

--- a/src/main/java/com/goggles/common/pagination/CommonCursorRequestArgumentResolver.java
+++ b/src/main/java/com/goggles/common/pagination/CommonCursorRequestArgumentResolver.java
@@ -1,0 +1,50 @@
+package com.goggles.common.pagination;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+/**
+ * 컨트롤러 파라미터로 선언된 {@link CommonCursorRequest}를 쿼리 파라미터에서 자동 바인딩.
+ *
+ * <p>{@code ?cursor=xxx&size=10} 형태로 요청하면 {@link CommonCursorRequest}로 변환됩니다.
+ * {@code cursor} 파라미터가 없으면 첫 페이지({@code null})로 처리됩니다.
+ *
+ * <pre>{@code
+ * @GetMapping("/feeds")
+ * public ApiResponse<CursorResponse<FeedResponse>> list(CommonCursorRequest cursorRequest) {
+ *     return ApiResponse.success(feedService.list(cursorRequest));
+ * }
+ * }</pre>
+ */
+public class CommonCursorRequestArgumentResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return CommonCursorRequest.class.equals(parameter.getParameterType());
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter,
+                                  ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest,
+                                  WebDataBinderFactory binderFactory) {
+        String cursor = webRequest.getParameter("cursor");
+        String sizeParam = webRequest.getParameter("size");
+
+        int size = parseOrDefault(sizeParam);
+
+        return CommonCursorRequest.of(cursor, size);
+    }
+
+    private int parseOrDefault(String value) {
+        if (value == null) return CommonPageRequest.DEFAULT_SIZE;
+        try {
+            return Integer.parseInt(value);
+        } catch (NumberFormatException e) {
+            return CommonPageRequest.DEFAULT_SIZE;
+        }
+    }
+}

--- a/src/main/java/com/goggles/common/pagination/CommonCursorResponse.java
+++ b/src/main/java/com/goggles/common/pagination/CommonCursorResponse.java
@@ -1,0 +1,58 @@
+package com.goggles.common.pagination;
+
+import lombok.Getter;
+
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * 커서 기반 페이지 응답 DTO.
+ *
+ * <p>{@code nextCursor}가 {@code null}이면 마지막 페이지입니다.
+ *
+ * <pre>{@code
+ * List<FeedEntity> feeds = feedRepository.findByCursor(cursor, size + 1);
+ * return CursorResponse.of(feeds, size, FeedResponse::from, FeedEntity::getCursorId);
+ * }</pre>
+ *
+ * @param <T> 콘텐츠 항목 타입
+ */
+@Getter
+public class CommonCursorResponse<T> {
+
+    private final List<T> content;
+    private final String nextCursor; // null이면 마지막 페이지
+    private final boolean hasNext;
+
+    private CommonCursorResponse(List<T> content, String nextCursor) {
+        this.content = content;
+        this.nextCursor = nextCursor;
+        this.hasNext = nextCursor != null;
+    }
+
+    // ── 팩토리 ────────────────────────────────────────────────────────────────
+
+    /**
+     * 엔티티 리스트 → DTO 리스트로 변환하며 다음 커서를 추출.
+     *
+     * <p>조회 시 {@code size + 1}개를 가져와서 다음 페이지 존재 여부를 판단합니다.
+     *
+     * @param entities     조회된 엔티티 목록 (size + 1개 조회 권장)
+     * @param size         요청 사이즈
+     * @param mapper       엔티티 → DTO 변환 함수
+     * @param cursorExtractor 다음 커서 값 추출 함수 (마지막 엔티티 기준)
+     */
+    public static <E, T> CommonCursorResponse<T> of(List<E> entities, int size,
+                                               Function<E, T> mapper,
+                                               Function<E, String> cursorExtractor) {
+        boolean hasNext = entities.size() > size;
+        List<E> sliced = hasNext ? entities.subList(0, size) : entities;
+        String nextCursor = hasNext ? cursorExtractor.apply(sliced.get(sliced.size() - 1)) : null;
+        return new CommonCursorResponse<>(sliced.stream().map(mapper).toList(), nextCursor);
+    }
+
+    /** 이미 변환된 DTO 리스트로 직접 생성. */
+    public static <T> CommonCursorResponse<T> of(List<T> content, String nextCursor) {
+        return new CommonCursorResponse<>(content, nextCursor);
+    }
+}

--- a/src/main/java/com/goggles/common/pagination/CommonCursorResponse.java
+++ b/src/main/java/com/goggles/common/pagination/CommonCursorResponse.java
@@ -20,39 +20,42 @@ import java.util.function.Function;
 @Getter
 public class CommonCursorResponse<T> {
 
-    private final List<T> content;
-    private final String nextCursor; // null이면 마지막 페이지
-    private final boolean hasNext;
+	private final List<T> content;
+	private final String nextCursor; // null이면 마지막 페이지
+	private final boolean hasNext;
 
-    private CommonCursorResponse(List<T> content, String nextCursor) {
-        this.content = content;
-        this.nextCursor = nextCursor;
-        this.hasNext = nextCursor != null;
-    }
+	private CommonCursorResponse(List<T> content, String nextCursor) {
+		this.content = content;
+		this.nextCursor = nextCursor;
+		this.hasNext = nextCursor != null;
+	}
 
-    // ── 팩토리 ────────────────────────────────────────────────────────────────
+	// ── 팩토리 ────────────────────────────────────────────────────────────────
 
-    /**
-     * 엔티티 리스트 → DTO 리스트로 변환하며 다음 커서를 추출.
-     *
-     * <p>조회 시 {@code size + 1}개를 가져와서 다음 페이지 존재 여부를 판단합니다.
-     *
-     * @param entities     조회된 엔티티 목록 (size + 1개 조회 권장)
-     * @param size         요청 사이즈
-     * @param mapper       엔티티 → DTO 변환 함수
-     * @param cursorExtractor 다음 커서 값 추출 함수 (마지막 엔티티 기준)
-     */
-    public static <E, T> CommonCursorResponse<T> of(List<E> entities, int size,
-                                               Function<E, T> mapper,
-                                               Function<E, String> cursorExtractor) {
-        boolean hasNext = entities.size() > size;
-        List<E> sliced = hasNext ? entities.subList(0, size) : entities;
-        String nextCursor = hasNext ? cursorExtractor.apply(sliced.get(sliced.size() - 1)) : null;
-        return new CommonCursorResponse<>(sliced.stream().map(mapper).toList(), nextCursor);
-    }
+	/**
+	 * 엔티티 리스트 → DTO 리스트로 변환하며 다음 커서를 추출.
+	 *
+	 * <p>조회 시 {@code size + 1}개를 가져와서 다음 페이지 존재 여부를 판단합니다.
+	 *
+	 * @param entities        조회된 엔티티 목록 (size + 1개 조회 권장)
+	 * @param size            요청 사이즈
+	 * @param mapper          엔티티 → DTO 변환 함수
+	 * @param cursorExtractor 다음 커서 값 추출 함수 (마지막 엔티티 기준)
+	 */
+	public static <E, T> CommonCursorResponse<T> of(List<E> entities, int size,
+			Function<E, T> mapper, Function<E, String> cursorExtractor) {
+		boolean hasNext = entities.size() > size;
+		List<E> sliced = hasNext ? entities.subList(0, size) : entities;
+		String nextCursor = hasNext ? cursorExtractor.apply(sliced.get(sliced.size() - 1)) : null;
+		return new CommonCursorResponse<>(sliced.stream()
+				.map(mapper)
+				.toList(), nextCursor);
+	}
 
-    /** 이미 변환된 DTO 리스트로 직접 생성. */
-    public static <T> CommonCursorResponse<T> of(List<T> content, String nextCursor) {
-        return new CommonCursorResponse<>(content, nextCursor);
-    }
+	/**
+	 * 이미 변환된 DTO 리스트로 직접 생성.
+	 */
+	public static <T> CommonCursorResponse<T> of(List<T> content, String nextCursor) {
+		return new CommonCursorResponse<>(content, nextCursor);
+	}
 }

--- a/src/main/java/com/goggles/common/pagination/CommonPageRequest.java
+++ b/src/main/java/com/goggles/common/pagination/CommonPageRequest.java
@@ -1,0 +1,54 @@
+package com.goggles.common.pagination;
+
+import lombok.Getter;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+import java.util.Set;
+
+/**
+ * 허용된 사이즈(10 / 30 / 50)만 받는 페이지 요청 DTO.
+ *
+ * <p>허용되지 않은 사이즈는 기본값 10으로 대체됩니다.
+ *
+ * <pre>{@code
+ * // Controller
+ * @GetMapping("/users")
+ * public ApiResponse<PageResponse<UserResponse>> list(
+ *         @RequestParam(defaultValue = "0") int page,
+ *         @RequestParam(defaultValue = "10") int size) {
+ *
+ *     Pageable pageable = CommonPageRequest.of(page, size).toPageable();
+ *     return ApiResponse.success(PageResponse.of(userService.list(pageable)));
+ * }
+ * }</pre>
+ */
+@Getter
+public class CommonPageRequest {
+
+    public static final Set<Integer> ALLOWED_SIZES = Set.of(10, 30, 50);
+    public static final int DEFAULT_SIZE = 10;
+
+    private final int page;   // 0-based
+    private final int size;   // 10 | 30 | 50
+
+    private CommonPageRequest(int page, int size) {
+        this.page = Math.max(0, page);
+        this.size = ALLOWED_SIZES.contains(size) ? size : DEFAULT_SIZE;
+    }
+
+    public static CommonPageRequest of(int page, int size) {
+        return new CommonPageRequest(page, size);
+    }
+
+    /** Spring Data {@link Pageable} 로 변환 (정렬 없음). */
+    public Pageable toPageable() {
+        return CommonPageRequest.of(page, size).toPageable(Sort.unsorted());
+    }
+
+    /** Spring Data {@link Pageable} 로 변환 (정렬 포함). */
+    public Pageable toPageable(Sort sort) {
+        return PageRequest.of(page, size, sort);
+    }
+}

--- a/src/main/java/com/goggles/common/pagination/CommonPageRequest.java
+++ b/src/main/java/com/goggles/common/pagination/CommonPageRequest.java
@@ -42,11 +42,6 @@ public class CommonPageRequest {
         return new CommonPageRequest(page, size);
     }
 
-    /** Spring Data {@link Pageable} 로 변환 (정렬 없음). */
-    public Pageable toPageable() {
-        return CommonPageRequest.of(page, size).toPageable(Sort.unsorted());
-    }
-
     /** Spring Data {@link Pageable} 로 변환 (정렬 포함). */
     public Pageable toPageable(Sort sort) {
         return PageRequest.of(page, size, sort);

--- a/src/main/java/com/goggles/common/pagination/CommonPageRequest.java
+++ b/src/main/java/com/goggles/common/pagination/CommonPageRequest.java
@@ -27,23 +27,25 @@ import java.util.Set;
 @Getter
 public class CommonPageRequest {
 
-    public static final Set<Integer> ALLOWED_SIZES = Set.of(10, 30, 50);
-    public static final int DEFAULT_SIZE = 10;
+	public static final Set<Integer> ALLOWED_SIZES = Set.of(10, 30, 50);
+	public static final int DEFAULT_SIZE = 10;
 
-    private final int page;   // 0-based
-    private final int size;   // 10 | 30 | 50
+	private final int page;   // 0-based
+	private final int size;   // 10 | 30 | 50
 
-    private CommonPageRequest(int page, int size) {
-        this.page = Math.max(0, page);
-        this.size = ALLOWED_SIZES.contains(size) ? size : DEFAULT_SIZE;
-    }
+	private CommonPageRequest(int page, int size) {
+		this.page = Math.max(0, page);
+		this.size = ALLOWED_SIZES.contains(size) ? size : DEFAULT_SIZE;
+	}
 
-    public static CommonPageRequest of(int page, int size) {
-        return new CommonPageRequest(page, size);
-    }
+	public static CommonPageRequest of(int page, int size) {
+		return new CommonPageRequest(page, size);
+	}
 
-    /** Spring Data {@link Pageable} 로 변환 (정렬 포함). */
-    public Pageable toPageable(Sort sort) {
-        return PageRequest.of(page, size, sort);
-    }
+	/**
+	 * Spring Data {@link Pageable} 로 변환 (정렬 포함).
+	 */
+	public Pageable toPageable(Sort sort) {
+		return PageRequest.of(page, size, sort);
+	}
 }

--- a/src/main/java/com/goggles/common/pagination/CommonPageRequestArgumentResolver.java
+++ b/src/main/java/com/goggles/common/pagination/CommonPageRequestArgumentResolver.java
@@ -1,0 +1,51 @@
+package com.goggles.common.pagination;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+/**
+ * 컨트롤러 파라미터로 선언된 {@link CommonPageRequest}를 쿼리 파라미터에서 자동 바인딩.
+ *
+ * <p>{@code ?page=0&size=10} 형태로 요청하면 {@link CommonPageRequest}로 변환됩니다.
+ * 허용되지 않은 size 값은 {@link CommonPageRequest#DEFAULT_SIZE}(10)으로 대체됩니다.
+ *
+ * <pre>{@code
+ * @GetMapping("/items")
+ * public ApiResponse<PageResponse<ItemResponse>> list(CommonPageRequest pageRequest) {
+ *     return ApiResponse.success(itemService.list(pageRequest.toPageable()));
+ * }
+ * }</pre>
+ */
+public class CommonPageRequestArgumentResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return CommonPageRequest.class.equals(parameter.getParameterType());
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter,
+                                  ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest,
+                                  WebDataBinderFactory binderFactory) {
+        String pageParam = webRequest.getParameter("page");
+        String sizeParam = webRequest.getParameter("size");
+
+        int page = parseOrDefault(pageParam, 0);
+        int size = parseOrDefault(sizeParam, CommonPageRequest.DEFAULT_SIZE);
+
+        return CommonPageRequest.of(page, size);
+    }
+
+    private int parseOrDefault(String value, int defaultValue) {
+        if (value == null) return defaultValue;
+        try {
+            return Integer.parseInt(value);
+        } catch (NumberFormatException e) {
+            return defaultValue;
+        }
+    }
+}

--- a/src/main/java/com/goggles/common/pagination/CommonPageRequestArgumentResolver.java
+++ b/src/main/java/com/goggles/common/pagination/CommonPageRequestArgumentResolver.java
@@ -21,31 +21,29 @@ import org.springframework.web.method.support.ModelAndViewContainer;
  */
 public class CommonPageRequestArgumentResolver implements HandlerMethodArgumentResolver {
 
-    @Override
-    public boolean supportsParameter(MethodParameter parameter) {
-        return CommonPageRequest.class.equals(parameter.getParameterType());
-    }
+	@Override
+	public boolean supportsParameter(MethodParameter parameter) {
+		return CommonPageRequest.class.equals(parameter.getParameterType());
+	}
 
-    @Override
-    public Object resolveArgument(MethodParameter parameter,
-                                  ModelAndViewContainer mavContainer,
-                                  NativeWebRequest webRequest,
-                                  WebDataBinderFactory binderFactory) {
-        String pageParam = webRequest.getParameter("page");
-        String sizeParam = webRequest.getParameter("size");
+	@Override
+	public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+			NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+		String pageParam = webRequest.getParameter("page");
+		String sizeParam = webRequest.getParameter("size");
 
-        int page = parseOrDefault(pageParam, 0);
-        int size = parseOrDefault(sizeParam, CommonPageRequest.DEFAULT_SIZE);
+		int page = parseOrDefault(pageParam, 0);
+		int size = parseOrDefault(sizeParam, CommonPageRequest.DEFAULT_SIZE);
 
-        return CommonPageRequest.of(page, size);
-    }
+		return CommonPageRequest.of(page, size);
+	}
 
-    private int parseOrDefault(String value, int defaultValue) {
-        if (value == null) return defaultValue;
-        try {
-            return Integer.parseInt(value);
-        } catch (NumberFormatException e) {
-            return defaultValue;
-        }
-    }
+	private int parseOrDefault(String value, int defaultValue) {
+		if (value == null) return defaultValue;
+		try {
+			return Integer.parseInt(value);
+		} catch (NumberFormatException e) {
+			return defaultValue;
+		}
+	}
 }

--- a/src/main/java/com/goggles/common/pagination/CommonPageResponse.java
+++ b/src/main/java/com/goggles/common/pagination/CommonPageResponse.java
@@ -21,70 +21,56 @@ import java.util.function.Function;
 @Getter
 public class CommonPageResponse<T> {
 
-    private final List<T> content;
-    private final int page;          // 0-based
-    private final int size;
-    private final long totalElements;
-    private final int totalPages;
-    private final boolean first;
-    private final boolean last;
+	private final List<T> content;
+	private final int page;          // 0-based
+	private final int size;
+	private final long totalElements;
+	private final int totalPages;
+	private final boolean first;
+	private final boolean last;
 
-    private CommonPageResponse(List<T> content, int page, int size,
-                         long totalElements, int totalPages,
-                         boolean first, boolean last) {
-        this.content = content;
-        this.page = page;
-        this.size = size;
-        this.totalElements = totalElements;
-        this.totalPages = totalPages;
-        this.first = first;
-        this.last = last;
-    }
+	private CommonPageResponse(List<T> content, int page, int size, long totalElements,
+			int totalPages, boolean first, boolean last) {
+		this.content = content;
+		this.page = page;
+		this.size = size;
+		this.totalElements = totalElements;
+		this.totalPages = totalPages;
+		this.first = first;
+		this.last = last;
+	}
 
-    // ── 팩토리 ────────────────────────────────────────────────────────────────
+	// ── 팩토리 ────────────────────────────────────────────────────────────────
 
-    /** Spring Data {@link Page} 를 그대로 변환. */
-    public static <T> CommonPageResponse<T> of(Page<T> page) {
-        return new CommonPageResponse<>(
-                page.getContent(),
-                page.getNumber(),
-                page.getSize(),
-                page.getTotalElements(),
-                page.getTotalPages(),
-                page.isFirst(),
-                page.isLast()
-        );
-    }
+	/**
+	 * Spring Data {@link Page} 를 그대로 변환.
+	 */
+	public static <T> CommonPageResponse<T> of(Page<T> page) {
+		return new CommonPageResponse<>(page.getContent(), page.getNumber(), page.getSize(),
+				page.getTotalElements(), page.getTotalPages(), page.isFirst(), page.isLast());
+	}
 
-    /**
-     * 엔티티 Page → DTO Page 로 변환 (매핑 함수 제공).
-     *
-     * @param page    Spring Data Page
-     * @param mapper  엔티티 → DTO 변환 함수
-     */
-    public static <E, T> CommonPageResponse<T> of(Page<E> page, Function<E, T> mapper) {
-        return new CommonPageResponse<>(
-                page.getContent().stream().map(mapper).toList(),
-                page.getNumber(),
-                page.getSize(),
-                page.getTotalElements(),
-                page.getTotalPages(),
-                page.isFirst(),
-                page.isLast()
-        );
-    }
+	/**
+	 * 엔티티 Page → DTO Page 로 변환 (매핑 함수 제공).
+	 *
+	 * @param page   Spring Data Page
+	 * @param mapper 엔티티 → DTO 변환 함수
+	 */
+	public static <E, T> CommonPageResponse<T> of(Page<E> page, Function<E, T> mapper) {
+		return new CommonPageResponse<>(page.getContent()
+				.stream()
+				.map(mapper)
+				.toList(), page.getNumber(), page.getSize(), page.getTotalElements(),
+				page.getTotalPages(), page.isFirst(), page.isLast());
+	}
 
-    /** Spring Data 의존 없이 직접 생성. */
-    public static <T> CommonPageResponse<T> of(List<T> content, int page, int size, long totalElements) {
-        int totalPages = size == 0 ? 1 : (int) Math.ceil((double) totalElements / size);
-        return new CommonPageResponse<>(
-                content,
-                page,
-                size,
-                totalElements,
-                totalPages,
-                page == 0,
-                page >= totalPages - 1
-        );
-    }
+	/**
+	 * Spring Data 의존 없이 직접 생성.
+	 */
+	public static <T> CommonPageResponse<T> of(List<T> content, int page, int size,
+			long totalElements) {
+		int totalPages = size == 0 ? 1 : (int) Math.ceil((double) totalElements / size);
+		return new CommonPageResponse<>(content, page, size, totalElements, totalPages, page == 0,
+				page >= totalPages - 1);
+	}
 }

--- a/src/main/java/com/goggles/common/pagination/CommonPageResponse.java
+++ b/src/main/java/com/goggles/common/pagination/CommonPageResponse.java
@@ -1,0 +1,90 @@
+package com.goggles.common.pagination;
+
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * 페이지네이션 응답 DTO.
+ *
+ * <p>Spring Data 의 {@link Page} 를 JSON 직렬화에 적합한 형태로 래핑합니다.
+ *
+ * <pre>{@code
+ * Page<UserEntity> page = userRepository.findAll(pageable);
+ * PageResponse<UserResponse> response = PageResponse.of(page, UserResponse::from);
+ * }</pre>
+ *
+ * @param <T> 콘텐츠 항목 타입
+ */
+@Getter
+public class CommonPageResponse<T> {
+
+    private final List<T> content;
+    private final int page;          // 0-based
+    private final int size;
+    private final long totalElements;
+    private final int totalPages;
+    private final boolean first;
+    private final boolean last;
+
+    private CommonPageResponse(List<T> content, int page, int size,
+                         long totalElements, int totalPages,
+                         boolean first, boolean last) {
+        this.content = content;
+        this.page = page;
+        this.size = size;
+        this.totalElements = totalElements;
+        this.totalPages = totalPages;
+        this.first = first;
+        this.last = last;
+    }
+
+    // ── 팩토리 ────────────────────────────────────────────────────────────────
+
+    /** Spring Data {@link Page} 를 그대로 변환. */
+    public static <T> CommonPageResponse<T> of(Page<T> page) {
+        return new CommonPageResponse<>(
+                page.getContent(),
+                page.getNumber(),
+                page.getSize(),
+                page.getTotalElements(),
+                page.getTotalPages(),
+                page.isFirst(),
+                page.isLast()
+        );
+    }
+
+    /**
+     * 엔티티 Page → DTO Page 로 변환 (매핑 함수 제공).
+     *
+     * @param page    Spring Data Page
+     * @param mapper  엔티티 → DTO 변환 함수
+     */
+    public static <E, T> CommonPageResponse<T> of(Page<E> page, Function<E, T> mapper) {
+        return new CommonPageResponse<>(
+                page.getContent().stream().map(mapper).toList(),
+                page.getNumber(),
+                page.getSize(),
+                page.getTotalElements(),
+                page.getTotalPages(),
+                page.isFirst(),
+                page.isLast()
+        );
+    }
+
+    /** Spring Data 의존 없이 직접 생성. */
+    public static <T> CommonPageResponse<T> of(List<T> content, int page, int size, long totalElements) {
+        int totalPages = size == 0 ? 1 : (int) Math.ceil((double) totalElements / size);
+        return new CommonPageResponse<>(
+                content,
+                page,
+                size,
+                totalElements,
+                totalPages,
+                page == 0,
+                page >= totalPages - 1
+        );
+    }
+}

--- a/src/main/java/com/goggles/common/response/ApiResponse.java
+++ b/src/main/java/com/goggles/common/response/ApiResponse.java
@@ -1,0 +1,18 @@
+package com.goggles.common.response;
+
+import org.slf4j.MDC;
+
+public record ApiResponse<T>(
+        boolean success,
+        String message,
+        T data,
+        String traceId
+) {
+    public static <T> ApiResponse<T> success(T data) {
+        return new ApiResponse<>(true, "요청이 성공적으로 처리되었습니다.", data, MDC.get("traceId"));
+    }
+
+    public static <T> ApiResponse<T> success(String message, T data) {
+        return new ApiResponse<>(true, message, data, MDC.get("traceId"));
+    }
+}

--- a/src/main/java/com/goggles/common/response/ApiResponse.java
+++ b/src/main/java/com/goggles/common/response/ApiResponse.java
@@ -2,17 +2,12 @@ package com.goggles.common.response;
 
 import org.slf4j.MDC;
 
-public record ApiResponse<T>(
-        boolean success,
-        String message,
-        T data,
-        String traceId
-) {
-    public static <T> ApiResponse<T> success(T data) {
-        return new ApiResponse<>(true, "요청이 성공적으로 처리되었습니다.", data, MDC.get("traceId"));
-    }
+public record ApiResponse<T>(boolean success, String message, T data, String traceId) {
+	public static <T> ApiResponse<T> success(T data) {
+		return new ApiResponse<>(true, "요청이 성공적으로 처리되었습니다.", data, MDC.get("traceId"));
+	}
 
-    public static <T> ApiResponse<T> success(String message, T data) {
-        return new ApiResponse<>(true, message, data, MDC.get("traceId"));
-    }
+	public static <T> ApiResponse<T> success(String message, T data) {
+		return new ApiResponse<>(true, message, data, MDC.get("traceId"));
+	}
 }

--- a/src/main/java/com/goggles/common/response/CommonResponseAdvice.java
+++ b/src/main/java/com/goggles/common/response/CommonResponseAdvice.java
@@ -11,31 +11,25 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
 
 @RestControllerAdvice(basePackages = "com.goggles")
-public class CommonResponseAdvice implements ResponseBodyAdvice<Object>  {
+public class CommonResponseAdvice implements ResponseBodyAdvice<Object> {
 	@Override
-	public boolean supports(MethodParameter returnType, Class<? extends HttpMessageConverter<?>> converterType) {
+	public boolean supports(MethodParameter returnType,
+			Class<? extends HttpMessageConverter<?>> converterType) {
 		Class<?> type = returnType.getParameterType();
 
 		// 이미 규격화된 응답이거나 특수 타입인 경우 제외
-		return !(type.equals(ApiResponse.class) ||
-				type.equals(ErrorResponse.class) ||
-				type.equals(ResponseEntity.class) ||
-				type.equals(String.class) ||
-				type.equals(Void.class) ||
-				type.isPrimitive()); // 기본 자료형 반환 시에도 주의 필요
+		return !(type.equals(ApiResponse.class) || type.equals(ErrorResponse.class) ||
+				type.equals(ResponseEntity.class) || type.equals(String.class) ||
+				type.equals(Void.class) || type.isPrimitive()); // 기본 자료형 반환 시에도 주의 필요
 	}
 
 	@Override
-	public Object beforeBodyWrite(Object body, MethodParameter returnType, MediaType selectedContentType,
+	public Object beforeBodyWrite(Object body, MethodParameter returnType,
+			MediaType selectedContentType,
 			Class<? extends HttpMessageConverter<?>> selectedConverterType,
 			ServerHttpRequest request, ServerHttpResponse response) {
 
 		// 컨트롤러가 반환한 데이터를 ApiResponse.success() 메서드로 감싸서 반환
-		return new ApiResponse<>(
-				true,
-				"요청이 성공적으로 처리되었습니다.",
-				body,
-				MDC.get("traceId")
-		);
+		return new ApiResponse<>(true, "요청이 성공적으로 처리되었습니다.", body, MDC.get("traceId"));
 	}
 }

--- a/src/main/java/com/goggles/common/response/CommonResponseAdvice.java
+++ b/src/main/java/com/goggles/common/response/CommonResponseAdvice.java
@@ -1,0 +1,41 @@
+package com.goggles.common.response;
+
+import org.slf4j.MDC;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
+
+@RestControllerAdvice(basePackages = "com.goggles")
+public class CommonResponseAdvice implements ResponseBodyAdvice<Object>  {
+	@Override
+	public boolean supports(MethodParameter returnType, Class<? extends HttpMessageConverter<?>> converterType) {
+		Class<?> type = returnType.getParameterType();
+
+		// 이미 규격화된 응답이거나 특수 타입인 경우 제외
+		return !(type.equals(ApiResponse.class) ||
+				type.equals(ErrorResponse.class) ||
+				type.equals(ResponseEntity.class) ||
+				type.equals(String.class) ||
+				type.equals(Void.class) ||
+				type.isPrimitive()); // 기본 자료형 반환 시에도 주의 필요
+	}
+
+	@Override
+	public Object beforeBodyWrite(Object body, MethodParameter returnType, MediaType selectedContentType,
+			Class<? extends HttpMessageConverter<?>> selectedConverterType,
+			ServerHttpRequest request, ServerHttpResponse response) {
+
+		// 컨트롤러가 반환한 데이터를 ApiResponse.success() 메서드로 감싸서 반환
+		return new ApiResponse<>(
+				true,
+				"요청이 성공적으로 처리되었습니다.",
+				body,
+				MDC.get("traceId")
+		);
+	}
+}

--- a/src/main/java/com/goggles/common/response/ErrorResponse.java
+++ b/src/main/java/com/goggles/common/response/ErrorResponse.java
@@ -1,48 +1,25 @@
 package com.goggles.common.response;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 import org.slf4j.MDC;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
 /**
  * 에러 상세 정보 DTO.
  */
 
-public record ErrorResponse(
-    int status,
-    String error,
-    Object message,
-    String field,
-    String traceId,
-    LocalDateTime timestamp
-) {
+public record ErrorResponse(int status, String error, Object message, String field, String traceId,
+							LocalDateTime timestamp) {
 
-    public static ErrorResponse of(HttpStatusCode status, Object message) {
-        return new ErrorResponse(
-                status.value(),
-                HttpStatus.valueOf(status.value()).name(),
-                message,
-                null,
-                MDC.get("traceId"),
-                LocalDateTime.now()
-        );
-    }
+	public static ErrorResponse of(HttpStatusCode status, Object message) {
+		return new ErrorResponse(status.value(), HttpStatus.valueOf(status.value())
+				.name(), message, null, MDC.get("traceId"), LocalDateTime.now());
+	}
 
-    public static ErrorResponse of(HttpStatusCode status, String field, Object message) {
-        return new ErrorResponse(
-                status.value(),
-                HttpStatus.valueOf(status.value()).name(),
-                message,
-                field,
-                MDC.get("traceId"),
-                LocalDateTime.now()
-        );
-    }
+	public static ErrorResponse of(HttpStatusCode status, String field, Object message) {
+		return new ErrorResponse(status.value(), HttpStatus.valueOf(status.value())
+				.name(), message, field, MDC.get("traceId"), LocalDateTime.now());
+	}
 }

--- a/src/main/java/com/goggles/common/response/ErrorResponse.java
+++ b/src/main/java/com/goggles/common/response/ErrorResponse.java
@@ -1,0 +1,48 @@
+package com.goggles.common.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.slf4j.MDC;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * 에러 상세 정보 DTO.
+ */
+
+public record ErrorResponse(
+    int status,
+    String error,
+    Object message,
+    String field,
+    String traceId,
+    LocalDateTime timestamp
+) {
+
+    public static ErrorResponse of(HttpStatusCode status, Object message) {
+        return new ErrorResponse(
+                status.value(),
+                HttpStatus.valueOf(status.value()).name(),
+                message,
+                null,
+                MDC.get("traceId"),
+                LocalDateTime.now()
+        );
+    }
+
+    public static ErrorResponse of(HttpStatusCode status, String field, Object message) {
+        return new ErrorResponse(
+                status.value(),
+                HttpStatus.valueOf(status.value()).name(),
+                message,
+                field,
+                MDC.get("traceId"),
+                LocalDateTime.now()
+        );
+    }
+}

--- a/src/main/java/com/goggles/common/util/MdcTaskDecorator.java
+++ b/src/main/java/com/goggles/common/util/MdcTaskDecorator.java
@@ -6,23 +6,23 @@ import org.springframework.core.task.TaskDecorator;
 import java.util.Map;
 
 public class MdcTaskDecorator implements TaskDecorator {
-    @Override
-    public Runnable decorate(Runnable runnable) {
-        // 현재(부모) 쓰레드의 MDC 컨텍스트 맵을 복사
-        Map<String, String> contextMap = MDC.getCopyOfContextMap();
+	@Override
+	public Runnable decorate(Runnable runnable) {
+		// 현재(부모) 쓰레드의 MDC 컨텍스트 맵을 복사
+		Map<String, String> contextMap = MDC.getCopyOfContextMap();
 
-        return () -> {
-            try {
-                // 새로운 (자식) 쓰레드에 복사해둔 컨텍스트 주입
-                if (contextMap != null) {
-                    MDC.setContextMap(contextMap);
-                }
+		return () -> {
+			try {
+				// 새로운 (자식) 쓰레드에 복사해둔 컨텍스트 주입
+				if (contextMap != null) {
+					MDC.setContextMap(contextMap);
+				}
 
-                runnable.run();
-            } finally {
-                // 자식 쓰레드 작업 종료 후 반드시 비우기 (쓰레드 풀 오염 방지)
-                MDC.clear();
-            }
-        };
-    }
+				runnable.run();
+			} finally {
+				// 자식 쓰레드 작업 종료 후 반드시 비우기 (쓰레드 풀 오염 방지)
+				MDC.clear();
+			}
+		};
+	}
 }

--- a/src/main/java/com/goggles/common/util/MdcTaskDecorator.java
+++ b/src/main/java/com/goggles/common/util/MdcTaskDecorator.java
@@ -1,0 +1,28 @@
+package com.goggles.common.util;
+
+import org.slf4j.MDC;
+import org.springframework.core.task.TaskDecorator;
+
+import java.util.Map;
+
+public class MdcTaskDecorator implements TaskDecorator {
+    @Override
+    public Runnable decorate(Runnable runnable) {
+        // 현재(부모) 쓰레드의 MDC 컨텍스트 맵을 복사
+        Map<String, String> contextMap = MDC.getCopyOfContextMap();
+
+        return () -> {
+            try {
+                // 새로운 (자식) 쓰레드에 복사해둔 컨텍스트 주입
+                if (contextMap != null) {
+                    MDC.setContextMap(contextMap);
+                }
+
+                runnable.run();
+            } finally {
+                // 자식 쓰레드 작업 종료 후 반드시 비우기 (쓰레드 풀 오염 방지)
+                MDC.clear();
+            }
+        };
+    }
+}

--- a/src/main/java/com/goggles/config/event/EventConfig.java
+++ b/src/main/java/com/goggles/config/event/EventConfig.java
@@ -1,0 +1,109 @@
+package com.goggles.config.event;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.goggles.common.domain.OutboxRepository;
+import com.goggles.common.event.Events;
+import com.goggles.common.domain.InboxRepository;
+import com.goggles.common.event.OutboxEventListener;
+import com.goggles.common.event.OutboxStatusUpdater;
+import com.goggles.common.event.advice.InboxAdvice;
+import com.goggles.common.event.scheduler.InboxCleanupScheduler;
+import com.goggles.common.event.scheduler.OutboxRelayScheduler;
+import com.goggles.common.filter.MdcLoggingFilter;
+import com.goggles.common.pagination.CommonCursorRequestArgumentResolver;
+import com.goggles.common.pagination.CommonPageRequestArgumentResolver;
+import com.goggles.common.util.MdcTaskDecorator;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.security.task.DelegatingSecurityContextAsyncTaskExecutor;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+import java.util.concurrent.Executor;
+
+@EnableAsync
+@Configuration
+@EnableScheduling
+@EnableAspectJAutoProxy(proxyTargetClass = true)
+public class EventConfig implements AsyncConfigurer {
+
+    // ── Event ────────────────────────────────────────────────────────────────
+
+    @Bean
+    public Events events(ApplicationEventPublisher eventPublisher) {
+        return new Events(eventPublisher);
+    }
+
+    @Bean
+    public OutboxStatusUpdater outboxStatusUpdater(OutboxRepository outboxRepository,
+            KafkaTemplate<String, Object> kafkaTemplate) {
+        return new OutboxStatusUpdater(outboxRepository, kafkaTemplate);
+    }
+
+    @Bean
+    public OutboxEventListener outboxEventListener(OutboxRepository outboxRepository,
+            KafkaTemplate<String, Object> kafkaTemplate, ObjectMapper objectMapper,
+            OutboxStatusUpdater outboxStatusUpdater) {
+        return new OutboxEventListener(outboxRepository, kafkaTemplate, objectMapper, outboxStatusUpdater);
+    }
+
+    @Bean
+    public OutboxRelayScheduler outboxRelayScheduler(OutboxRepository outboxRepository,
+            KafkaTemplate<String, Object> kafkaTemplate, OutboxStatusUpdater outboxStatusUpdater) {
+        return new OutboxRelayScheduler(outboxRepository, kafkaTemplate, outboxStatusUpdater);
+    }
+
+    @Bean
+    public InboxAdvice inboxAdvice(InboxRepository inboxRepository) {
+        return new InboxAdvice(inboxRepository);
+    }
+
+    @Bean
+    public InboxCleanupScheduler inboxCleanupScheduler(InboxRepository inboxRepository) {
+        return new InboxCleanupScheduler(inboxRepository);
+    }
+
+    // ── Filter ───────────────────────────────────────────────────────────────
+
+    @Bean
+    public MdcLoggingFilter mdcLoggingFilter() {
+        return new MdcLoggingFilter();
+    }
+
+    // ── ArgumentResolver ─────────────────────────────────────────────────────
+
+    @Bean
+    public WebMvcConfigurer commonArgumentResolverConfigurer() {
+        return new WebMvcConfigurer() {
+            @Override
+            public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+                resolvers.add(new CommonPageRequestArgumentResolver());
+                resolvers.add(new CommonCursorRequestArgumentResolver());
+            }
+        };
+    }
+
+    // ── Async ────────────────────────────────────────────────────────────────
+
+    @Override
+    public Executor getAsyncExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(10);
+        executor.setMaxPoolSize(50);
+        executor.setQueueCapacity(100);
+        executor.setThreadNamePrefix("Async-");
+        executor.setTaskDecorator(new MdcTaskDecorator());
+        executor.setWaitForTasksToCompleteOnShutdown(true);
+        executor.setAwaitTerminationSeconds(60);
+        executor.initialize();
+        return new DelegatingSecurityContextAsyncTaskExecutor(executor);
+    }
+}

--- a/src/main/java/com/goggles/config/event/EventConfig.java
+++ b/src/main/java/com/goggles/config/event/EventConfig.java
@@ -1,9 +1,9 @@
 package com.goggles.config.event;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.goggles.common.domain.InboxRepository;
 import com.goggles.common.domain.OutboxRepository;
 import com.goggles.common.event.Events;
-import com.goggles.common.domain.InboxRepository;
 import com.goggles.common.event.OutboxEventListener;
 import com.goggles.common.event.OutboxStatusUpdater;
 import com.goggles.common.event.advice.InboxAdvice;
@@ -35,75 +35,76 @@ import java.util.concurrent.Executor;
 @EnableAspectJAutoProxy(proxyTargetClass = true)
 public class EventConfig implements AsyncConfigurer {
 
-    // ── Event ────────────────────────────────────────────────────────────────
+	// ── Event ────────────────────────────────────────────────────────────────
 
-    @Bean
-    public Events events(ApplicationEventPublisher eventPublisher) {
-        return new Events(eventPublisher);
-    }
+	@Bean
+	public Events events(ApplicationEventPublisher eventPublisher) {
+		return new Events(eventPublisher);
+	}
 
-    @Bean
-    public OutboxStatusUpdater outboxStatusUpdater(OutboxRepository outboxRepository,
-            KafkaTemplate<String, Object> kafkaTemplate) {
-        return new OutboxStatusUpdater(outboxRepository, kafkaTemplate);
-    }
+	@Bean
+	public OutboxStatusUpdater outboxStatusUpdater(OutboxRepository outboxRepository,
+			KafkaTemplate<String, Object> kafkaTemplate) {
+		return new OutboxStatusUpdater(outboxRepository, kafkaTemplate);
+	}
 
-    @Bean
-    public OutboxEventListener outboxEventListener(OutboxRepository outboxRepository,
-            KafkaTemplate<String, Object> kafkaTemplate, ObjectMapper objectMapper,
-            OutboxStatusUpdater outboxStatusUpdater) {
-        return new OutboxEventListener(outboxRepository, kafkaTemplate, objectMapper, outboxStatusUpdater);
-    }
+	@Bean
+	public OutboxEventListener outboxEventListener(OutboxRepository outboxRepository,
+			KafkaTemplate<String, Object> kafkaTemplate, ObjectMapper objectMapper,
+			OutboxStatusUpdater outboxStatusUpdater) {
+		return new OutboxEventListener(outboxRepository, kafkaTemplate, objectMapper,
+				outboxStatusUpdater);
+	}
 
-    @Bean
-    public OutboxRelayScheduler outboxRelayScheduler(OutboxRepository outboxRepository,
-            KafkaTemplate<String, Object> kafkaTemplate, OutboxStatusUpdater outboxStatusUpdater) {
-        return new OutboxRelayScheduler(outboxRepository, kafkaTemplate, outboxStatusUpdater);
-    }
+	@Bean
+	public OutboxRelayScheduler outboxRelayScheduler(OutboxRepository outboxRepository,
+			KafkaTemplate<String, Object> kafkaTemplate, OutboxStatusUpdater outboxStatusUpdater) {
+		return new OutboxRelayScheduler(outboxRepository, kafkaTemplate, outboxStatusUpdater);
+	}
 
-    @Bean
-    public InboxAdvice inboxAdvice(InboxRepository inboxRepository) {
-        return new InboxAdvice(inboxRepository);
-    }
+	@Bean
+	public InboxAdvice inboxAdvice(InboxRepository inboxRepository) {
+		return new InboxAdvice(inboxRepository);
+	}
 
-    @Bean
-    public InboxCleanupScheduler inboxCleanupScheduler(InboxRepository inboxRepository) {
-        return new InboxCleanupScheduler(inboxRepository);
-    }
+	@Bean
+	public InboxCleanupScheduler inboxCleanupScheduler(InboxRepository inboxRepository) {
+		return new InboxCleanupScheduler(inboxRepository);
+	}
 
-    // ── Filter ───────────────────────────────────────────────────────────────
+	// ── Filter ───────────────────────────────────────────────────────────────
 
-    @Bean
-    public MdcLoggingFilter mdcLoggingFilter() {
-        return new MdcLoggingFilter();
-    }
+	@Bean
+	public MdcLoggingFilter mdcLoggingFilter() {
+		return new MdcLoggingFilter();
+	}
 
-    // ── ArgumentResolver ─────────────────────────────────────────────────────
+	// ── ArgumentResolver ─────────────────────────────────────────────────────
 
-    @Bean
-    public WebMvcConfigurer commonArgumentResolverConfigurer() {
-        return new WebMvcConfigurer() {
-            @Override
-            public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
-                resolvers.add(new CommonPageRequestArgumentResolver());
-                resolvers.add(new CommonCursorRequestArgumentResolver());
-            }
-        };
-    }
+	@Bean
+	public WebMvcConfigurer commonArgumentResolverConfigurer() {
+		return new WebMvcConfigurer() {
+			@Override
+			public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+				resolvers.add(new CommonPageRequestArgumentResolver());
+				resolvers.add(new CommonCursorRequestArgumentResolver());
+			}
+		};
+	}
 
-    // ── Async ────────────────────────────────────────────────────────────────
+	// ── Async ────────────────────────────────────────────────────────────────
 
-    @Override
-    public Executor getAsyncExecutor() {
-        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
-        executor.setCorePoolSize(10);
-        executor.setMaxPoolSize(50);
-        executor.setQueueCapacity(100);
-        executor.setThreadNamePrefix("Async-");
-        executor.setTaskDecorator(new MdcTaskDecorator());
-        executor.setWaitForTasksToCompleteOnShutdown(true);
-        executor.setAwaitTerminationSeconds(60);
-        executor.initialize();
-        return new DelegatingSecurityContextAsyncTaskExecutor(executor);
-    }
+	@Override
+	public Executor getAsyncExecutor() {
+		ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+		executor.setCorePoolSize(10);
+		executor.setMaxPoolSize(50);
+		executor.setQueueCapacity(100);
+		executor.setThreadNamePrefix("Async-");
+		executor.setTaskDecorator(new MdcTaskDecorator());
+		executor.setWaitForTasksToCompleteOnShutdown(true);
+		executor.setAwaitTerminationSeconds(60);
+		executor.initialize();
+		return new DelegatingSecurityContextAsyncTaskExecutor(executor);
+	}
 }

--- a/src/test/java/com/goggles/common/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/goggles/common/GlobalExceptionHandlerTest.java
@@ -1,8 +1,8 @@
 package com.goggles.common;
 
+import com.goggles.common.exception.BadRequestException;
 import com.goggles.common.exception.GlobalExceptionAdvice;
 import com.goggles.common.exception.NotFoundException;
-import com.goggles.common.exception.BadRequestException;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -22,49 +22,49 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @Import(GlobalExceptionAdvice.class)
 class GlobalExceptionHandlerTest {
 
-    @Autowired
-    MockMvc mockMvc;
+	@Autowired
+	MockMvc mockMvc;
 
-    @Test
-    void NotFoundException_발생시_404와_에러_포맷으로_응답한다() throws Exception {
-        mockMvc.perform(get("/test/not-found").accept(MediaType.APPLICATION_JSON))
-                .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.status").value(404))
-                .andExpect(jsonPath("$.error").value("NOT_FOUND"))
-                .andExpect(jsonPath("$.message").value("리소스를 찾을 수 없습니다"));
-    }
+	@Test
+	void NotFoundException_발생시_404와_에러_포맷으로_응답한다() throws Exception {
+		mockMvc.perform(get("/test/not-found").accept(MediaType.APPLICATION_JSON))
+				.andExpect(status().isNotFound())
+				.andExpect(jsonPath("$.status").value(404))
+				.andExpect(jsonPath("$.error").value("NOT_FOUND"))
+				.andExpect(jsonPath("$.message").value("리소스를 찾을 수 없습니다"));
+	}
 
-    @Test
-    void BadRequestException_발생시_400으로_응답한다() throws Exception {
-        mockMvc.perform(get("/test/bad-request").accept(MediaType.APPLICATION_JSON))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.status").value(400))
-                .andExpect(jsonPath("$.error").value("BAD_REQUEST"));
-    }
+	@Test
+	void BadRequestException_발생시_400으로_응답한다() throws Exception {
+		mockMvc.perform(get("/test/bad-request").accept(MediaType.APPLICATION_JSON))
+				.andExpect(status().isBadRequest())
+				.andExpect(jsonPath("$.status").value(400))
+				.andExpect(jsonPath("$.error").value("BAD_REQUEST"));
+	}
 
-    @Test
-    void 처리되지_않은_예외는_500으로_응답한다() throws Exception {
-        mockMvc.perform(get("/test/unknown-error").accept(MediaType.APPLICATION_JSON))
-                .andExpect(status().isInternalServerError())
-                .andExpect(jsonPath("$.status").value(500))
-                .andExpect(jsonPath("$.error").value("INTERNAL_SERVER_ERROR"));
-    }
+	@Test
+	void 처리되지_않은_예외는_500으로_응답한다() throws Exception {
+		mockMvc.perform(get("/test/unknown-error").accept(MediaType.APPLICATION_JSON))
+				.andExpect(status().isInternalServerError())
+				.andExpect(jsonPath("$.status").value(500))
+				.andExpect(jsonPath("$.error").value("INTERNAL_SERVER_ERROR"));
+	}
 
-    @RestController
-    static class TestController {
-        @GetMapping("/test/not-found")
-        void notFound() {
-            throw new NotFoundException("리소스를 찾을 수 없습니다");
-        }
+	@RestController
+	static class TestController {
+		@GetMapping("/test/not-found")
+		void notFound() {
+			throw new NotFoundException("리소스를 찾을 수 없습니다");
+		}
 
-        @GetMapping("/test/bad-request")
-        void badRequest() {
-            throw new BadRequestException("잘못된 요청입니다");
-        }
+		@GetMapping("/test/bad-request")
+		void badRequest() {
+			throw new BadRequestException("잘못된 요청입니다");
+		}
 
-        @GetMapping("/test/unknown-error")
-        void unknownError() {
-            throw new RuntimeException("예상치 못한 에러");
-        }
-    }
+		@GetMapping("/test/unknown-error")
+		void unknownError() {
+			throw new RuntimeException("예상치 못한 에러");
+		}
+	}
 }

--- a/src/test/java/com/goggles/common/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/goggles/common/GlobalExceptionHandlerTest.java
@@ -1,0 +1,70 @@
+package com.goggles.common;
+
+import com.goggles.common.exception.GlobalExceptionAdvice;
+import com.goggles.common.exception.NotFoundException;
+import com.goggles.common.exception.BadRequestException;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest
+@ContextConfiguration(classes = {GlobalExceptionHandlerTest.TestController.class})
+@Import(GlobalExceptionAdvice.class)
+class GlobalExceptionHandlerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Test
+    void NotFoundException_발생시_404와_에러_포맷으로_응답한다() throws Exception {
+        mockMvc.perform(get("/test/not-found").accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.status").value(404))
+                .andExpect(jsonPath("$.error").value("NOT_FOUND"))
+                .andExpect(jsonPath("$.message").value("리소스를 찾을 수 없습니다"));
+    }
+
+    @Test
+    void BadRequestException_발생시_400으로_응답한다() throws Exception {
+        mockMvc.perform(get("/test/bad-request").accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.error").value("BAD_REQUEST"));
+    }
+
+    @Test
+    void 처리되지_않은_예외는_500으로_응답한다() throws Exception {
+        mockMvc.perform(get("/test/unknown-error").accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isInternalServerError())
+                .andExpect(jsonPath("$.status").value(500))
+                .andExpect(jsonPath("$.error").value("INTERNAL_SERVER_ERROR"));
+    }
+
+    @RestController
+    static class TestController {
+        @GetMapping("/test/not-found")
+        void notFound() {
+            throw new NotFoundException("리소스를 찾을 수 없습니다");
+        }
+
+        @GetMapping("/test/bad-request")
+        void badRequest() {
+            throw new BadRequestException("잘못된 요청입니다");
+        }
+
+        @GetMapping("/test/unknown-error")
+        void unknownError() {
+            throw new RuntimeException("예상치 못한 에러");
+        }
+    }
+}

--- a/src/test/java/com/goggles/common/PageResponseTest.java
+++ b/src/test/java/com/goggles/common/PageResponseTest.java
@@ -1,0 +1,45 @@
+package com.goggles.common;
+
+import com.goggles.common.pagination.CommonPageResponse;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PageResponseTest {
+
+    @Test
+    void springPage를_CommonPageResponse로_변환한다() {
+        var page = new PageImpl<>(List.of("a", "b"), PageRequest.of(0, 10), 2);
+        CommonPageResponse<String> response = CommonPageResponse.of(page);
+
+        assertThat(response.getContent()).containsExactly("a", "b");
+        assertThat(response.getTotalElements()).isEqualTo(2);
+        assertThat(response.isFirst()).isTrue();
+        assertThat(response.isLast()).isTrue();
+    }
+
+    @Test
+    void mapper로_엔티티를_DTO로_변환한다() {
+        var page = new PageImpl<>(List.of(1, 2, 3), PageRequest.of(1, 3), 9);
+        CommonPageResponse<String> response = CommonPageResponse.of(page, String::valueOf);
+
+        assertThat(response.getContent()).containsExactly("1", "2", "3");
+        assertThat(response.getPage()).isEqualTo(1);
+        assertThat(response.getTotalPages()).isEqualTo(3);
+        assertThat(response.isFirst()).isFalse();
+        assertThat(response.isLast()).isFalse();
+    }
+
+    @Test
+    void 직접_생성시_totalPages가_올바르게_계산된다() {
+        CommonPageResponse<String> response = CommonPageResponse.of(List.of("a", "b"), 0, 10, 25);
+
+        assertThat(response.getTotalPages()).isEqualTo(3);
+        assertThat(response.isFirst()).isTrue();
+        assertThat(response.isLast()).isFalse();
+    }
+}

--- a/src/test/java/com/goggles/common/PageResponseTest.java
+++ b/src/test/java/com/goggles/common/PageResponseTest.java
@@ -11,35 +11,35 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class PageResponseTest {
 
-    @Test
-    void springPage를_CommonPageResponse로_변환한다() {
-        var page = new PageImpl<>(List.of("a", "b"), PageRequest.of(0, 10), 2);
-        CommonPageResponse<String> response = CommonPageResponse.of(page);
+	@Test
+	void springPage를_CommonPageResponse로_변환한다() {
+		var page = new PageImpl<>(List.of("a", "b"), PageRequest.of(0, 10), 2);
+		CommonPageResponse<String> response = CommonPageResponse.of(page);
 
-        assertThat(response.getContent()).containsExactly("a", "b");
-        assertThat(response.getTotalElements()).isEqualTo(2);
-        assertThat(response.isFirst()).isTrue();
-        assertThat(response.isLast()).isTrue();
-    }
+		assertThat(response.getContent()).containsExactly("a", "b");
+		assertThat(response.getTotalElements()).isEqualTo(2);
+		assertThat(response.isFirst()).isTrue();
+		assertThat(response.isLast()).isTrue();
+	}
 
-    @Test
-    void mapper로_엔티티를_DTO로_변환한다() {
-        var page = new PageImpl<>(List.of(1, 2, 3), PageRequest.of(1, 3), 9);
-        CommonPageResponse<String> response = CommonPageResponse.of(page, String::valueOf);
+	@Test
+	void mapper로_엔티티를_DTO로_변환한다() {
+		var page = new PageImpl<>(List.of(1, 2, 3), PageRequest.of(1, 3), 9);
+		CommonPageResponse<String> response = CommonPageResponse.of(page, String::valueOf);
 
-        assertThat(response.getContent()).containsExactly("1", "2", "3");
-        assertThat(response.getPage()).isEqualTo(1);
-        assertThat(response.getTotalPages()).isEqualTo(3);
-        assertThat(response.isFirst()).isFalse();
-        assertThat(response.isLast()).isFalse();
-    }
+		assertThat(response.getContent()).containsExactly("1", "2", "3");
+		assertThat(response.getPage()).isEqualTo(1);
+		assertThat(response.getTotalPages()).isEqualTo(3);
+		assertThat(response.isFirst()).isFalse();
+		assertThat(response.isLast()).isFalse();
+	}
 
-    @Test
-    void 직접_생성시_totalPages가_올바르게_계산된다() {
-        CommonPageResponse<String> response = CommonPageResponse.of(List.of("a", "b"), 0, 10, 25);
+	@Test
+	void 직접_생성시_totalPages가_올바르게_계산된다() {
+		CommonPageResponse<String> response = CommonPageResponse.of(List.of("a", "b"), 0, 10, 25);
 
-        assertThat(response.getTotalPages()).isEqualTo(3);
-        assertThat(response.isFirst()).isTrue();
-        assertThat(response.isLast()).isFalse();
-    }
+		assertThat(response.getTotalPages()).isEqualTo(3);
+		assertThat(response.isFirst()).isTrue();
+		assertThat(response.isLast()).isFalse();
+	}
 }

--- a/src/test/java/com/goggles/common/outbox/OutboxEventListenerTest.java
+++ b/src/test/java/com/goggles/common/outbox/OutboxEventListenerTest.java
@@ -1,0 +1,127 @@
+package com.goggles.common.outbox;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.goggles.common.domain.Outbox;
+import com.goggles.common.domain.OutboxRepository;
+import com.goggles.common.domain.OutboxStatus;
+import com.goggles.common.event.OutboxEvent;
+import com.goggles.common.event.OutboxEventListener;
+import com.goggles.common.event.OutboxStatusUpdater;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@SuppressWarnings("unchecked")
+@ExtendWith(MockitoExtension.class)
+class OutboxEventListenerTest {
+
+    @Mock OutboxRepository outboxRepository;
+    @Mock KafkaTemplate<String, Object> kafkaTemplate;
+    @Mock ObjectMapper objectMapper;
+    @Mock OutboxStatusUpdater outboxStatusUpdater;
+
+    @InjectMocks
+    OutboxEventListener listener;
+
+    private static final OutboxEvent EVENT = new OutboxEvent(
+            "corr-1", "ORDER", "OrderCreatedEvent", "{\"amount\":1000}");
+
+    // ── recordOutbox ──────────────────────────────────────────────────────────
+
+    @Test
+    void 새로운_correlationId면_PENDING으로_저장한다() throws Exception {
+        given(outboxRepository.existsByCorrelationId("corr-1")).willReturn(false);
+        given(objectMapper.writeValueAsString(any())).willReturn("{\"amount\":1000}");
+
+        listener.recordOutbox(EVENT);
+
+        verify(outboxRepository).save(argThat(o ->
+                "corr-1".equals(o.getCorrelationId()) &&
+                OutboxStatus.PENDING.equals(o.getStatus())
+        ));
+    }
+
+    @Test
+    void 중복된_correlationId면_저장하지_않는다() {
+        given(outboxRepository.existsByCorrelationId("corr-1")).willReturn(true);
+
+        listener.recordOutbox(EVENT);
+
+        verify(outboxRepository, never()).save(any());
+    }
+
+    @Test
+    void 직렬화_실패시_Outbox를_저장하지_않는다() throws Exception {
+        given(outboxRepository.existsByCorrelationId("corr-1")).willReturn(false);
+        given(objectMapper.writeValueAsString(any()))
+                .willThrow(new JsonProcessingException("직렬화 실패") {});
+
+        listener.recordOutbox(EVENT);
+
+        verify(outboxRepository, never()).save(any());
+    }
+
+    // ── publish ───────────────────────────────────────────────────────────────
+
+    @Test
+    void Kafka_발행_성공시_handleSuccess를_호출한다() {
+        Outbox outbox = buildOutbox(UUID.randomUUID(), OutboxStatus.PENDING);
+        given(outboxRepository.findByCorrelationId("corr-1")).willReturn(Optional.of(outbox));
+        given(kafkaTemplate.send(any(org.apache.kafka.clients.producer.ProducerRecord.class)))
+                .willReturn(CompletableFuture.completedFuture(mock(SendResult.class)));
+
+        listener.publish(EVENT);
+
+        verify(outboxStatusUpdater).handleSuccess("corr-1");
+    }
+
+    @Test
+    void Kafka_발행_실패시_handleFailure를_호출한다() {
+        Outbox outbox = buildOutbox(UUID.randomUUID(), OutboxStatus.PENDING);
+        given(outboxRepository.findByCorrelationId("corr-1")).willReturn(Optional.of(outbox));
+        given(kafkaTemplate.send(any(org.apache.kafka.clients.producer.ProducerRecord.class)))
+                .willReturn(CompletableFuture.failedFuture(new RuntimeException("Kafka 연결 실패")));
+
+        listener.publish(EVENT);
+
+        verify(outboxStatusUpdater).handleFailure(eq(EVENT), any(Throwable.class));
+    }
+
+    @Test
+    void Outbox가_없으면_Kafka_발행하지_않는다() {
+        given(outboxRepository.findByCorrelationId("corr-1")).willReturn(Optional.empty());
+
+        listener.publish(EVENT);
+
+        verifyNoInteractions(kafkaTemplate);
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    private Outbox buildOutbox(UUID id, OutboxStatus status) {
+        Outbox outbox = Outbox.builder()
+                .correlationId("corr-1")
+                .domainType("ORDER")
+                .eventType("OrderCreatedEvent")
+                .payload("{\"amount\":1000}")
+                .status(status)
+                .build();
+        ReflectionTestUtils.setField(outbox, "id", id);
+        return outbox;
+    }
+}

--- a/src/test/java/com/goggles/common/outbox/OutboxEventListenerTest.java
+++ b/src/test/java/com/goggles/common/outbox/OutboxEventListenerTest.java
@@ -30,98 +30,100 @@ import static org.mockito.Mockito.*;
 @ExtendWith(MockitoExtension.class)
 class OutboxEventListenerTest {
 
-    @Mock OutboxRepository outboxRepository;
-    @Mock KafkaTemplate<String, Object> kafkaTemplate;
-    @Mock ObjectMapper objectMapper;
-    @Mock OutboxStatusUpdater outboxStatusUpdater;
+	private static final OutboxEvent EVENT =
+			new OutboxEvent("corr-1", "ORDER", "OrderCreatedEvent", "{\"amount\":1000}");
+	@Mock
+	OutboxRepository outboxRepository;
+	@Mock
+	KafkaTemplate<String, Object> kafkaTemplate;
+	@Mock
+	ObjectMapper objectMapper;
+	@Mock
+	OutboxStatusUpdater outboxStatusUpdater;
+	@InjectMocks
+	OutboxEventListener listener;
 
-    @InjectMocks
-    OutboxEventListener listener;
+	// ── recordOutbox ──────────────────────────────────────────────────────────
 
-    private static final OutboxEvent EVENT = new OutboxEvent(
-            "corr-1", "ORDER", "OrderCreatedEvent", "{\"amount\":1000}");
+	@Test
+	void 새로운_correlationId면_PENDING으로_저장한다() throws Exception {
+		given(outboxRepository.existsByCorrelationId("corr-1")).willReturn(false);
+		given(objectMapper.writeValueAsString(any())).willReturn("{\"amount\":1000}");
 
-    // ── recordOutbox ──────────────────────────────────────────────────────────
+		listener.recordOutbox(EVENT);
 
-    @Test
-    void 새로운_correlationId면_PENDING으로_저장한다() throws Exception {
-        given(outboxRepository.existsByCorrelationId("corr-1")).willReturn(false);
-        given(objectMapper.writeValueAsString(any())).willReturn("{\"amount\":1000}");
+		verify(outboxRepository).save(argThat(o -> "corr-1".equals(o.getCorrelationId()) &&
+				OutboxStatus.PENDING.equals(o.getStatus())));
+	}
 
-        listener.recordOutbox(EVENT);
+	@Test
+	void 중복된_correlationId면_저장하지_않는다() {
+		given(outboxRepository.existsByCorrelationId("corr-1")).willReturn(true);
 
-        verify(outboxRepository).save(argThat(o ->
-                "corr-1".equals(o.getCorrelationId()) &&
-                OutboxStatus.PENDING.equals(o.getStatus())
-        ));
-    }
+		listener.recordOutbox(EVENT);
 
-    @Test
-    void 중복된_correlationId면_저장하지_않는다() {
-        given(outboxRepository.existsByCorrelationId("corr-1")).willReturn(true);
+		verify(outboxRepository, never()).save(any());
+	}
 
-        listener.recordOutbox(EVENT);
+	@Test
+	void 직렬화_실패시_Outbox를_저장하지_않는다() throws Exception {
+		given(outboxRepository.existsByCorrelationId("corr-1")).willReturn(false);
+		given(objectMapper.writeValueAsString(any())).willThrow(
+				new JsonProcessingException("직렬화 실패") {});
 
-        verify(outboxRepository, never()).save(any());
-    }
+		listener.recordOutbox(EVENT);
 
-    @Test
-    void 직렬화_실패시_Outbox를_저장하지_않는다() throws Exception {
-        given(outboxRepository.existsByCorrelationId("corr-1")).willReturn(false);
-        given(objectMapper.writeValueAsString(any()))
-                .willThrow(new JsonProcessingException("직렬화 실패") {});
+		verify(outboxRepository, never()).save(any());
+	}
 
-        listener.recordOutbox(EVENT);
+	// ── publish ───────────────────────────────────────────────────────────────
 
-        verify(outboxRepository, never()).save(any());
-    }
+	@Test
+	void Kafka_발행_성공시_handleSuccess를_호출한다() {
+		Outbox outbox = buildOutbox(UUID.randomUUID(), OutboxStatus.PENDING);
+		given(outboxRepository.findByCorrelationId("corr-1")).willReturn(Optional.of(outbox));
+		given(kafkaTemplate.send(
+				any(org.apache.kafka.clients.producer.ProducerRecord.class))).willReturn(
+				CompletableFuture.completedFuture(mock(SendResult.class)));
 
-    // ── publish ───────────────────────────────────────────────────────────────
+		listener.publish(EVENT);
 
-    @Test
-    void Kafka_발행_성공시_handleSuccess를_호출한다() {
-        Outbox outbox = buildOutbox(UUID.randomUUID(), OutboxStatus.PENDING);
-        given(outboxRepository.findByCorrelationId("corr-1")).willReturn(Optional.of(outbox));
-        given(kafkaTemplate.send(any(org.apache.kafka.clients.producer.ProducerRecord.class)))
-                .willReturn(CompletableFuture.completedFuture(mock(SendResult.class)));
+		verify(outboxStatusUpdater).handleSuccess("corr-1");
+	}
 
-        listener.publish(EVENT);
+	@Test
+	void Kafka_발행_실패시_handleFailure를_호출한다() {
+		Outbox outbox = buildOutbox(UUID.randomUUID(), OutboxStatus.PENDING);
+		given(outboxRepository.findByCorrelationId("corr-1")).willReturn(Optional.of(outbox));
+		given(kafkaTemplate.send(
+				any(org.apache.kafka.clients.producer.ProducerRecord.class))).willReturn(
+				CompletableFuture.failedFuture(new RuntimeException("Kafka 연결 실패")));
 
-        verify(outboxStatusUpdater).handleSuccess("corr-1");
-    }
+		listener.publish(EVENT);
 
-    @Test
-    void Kafka_발행_실패시_handleFailure를_호출한다() {
-        Outbox outbox = buildOutbox(UUID.randomUUID(), OutboxStatus.PENDING);
-        given(outboxRepository.findByCorrelationId("corr-1")).willReturn(Optional.of(outbox));
-        given(kafkaTemplate.send(any(org.apache.kafka.clients.producer.ProducerRecord.class)))
-                .willReturn(CompletableFuture.failedFuture(new RuntimeException("Kafka 연결 실패")));
+		verify(outboxStatusUpdater).handleFailure(eq(EVENT), any(Throwable.class));
+	}
 
-        listener.publish(EVENT);
+	@Test
+	void Outbox가_없으면_Kafka_발행하지_않는다() {
+		given(outboxRepository.findByCorrelationId("corr-1")).willReturn(Optional.empty());
 
-        verify(outboxStatusUpdater).handleFailure(eq(EVENT), any(Throwable.class));
-    }
+		listener.publish(EVENT);
 
-    @Test
-    void Outbox가_없으면_Kafka_발행하지_않는다() {
-        given(outboxRepository.findByCorrelationId("corr-1")).willReturn(Optional.empty());
+		verifyNoInteractions(kafkaTemplate);
+	}
 
-        listener.publish(EVENT);
+	// ── helpers ───────────────────────────────────────────────────────────────
 
-        verifyNoInteractions(kafkaTemplate);
-    }
-
-    // ── helpers ───────────────────────────────────────────────────────────────
-
-    private Outbox buildOutbox(UUID id, OutboxStatus status) {
-        Outbox outbox = Outbox.builder()
-                .correlationId("corr-1")
-                .domainType("ORDER")
-                .eventType("OrderCreatedEvent")
-                .payload("{\"amount\":1000}")
-                .status(status)
-                .build();
-        ReflectionTestUtils.setField(outbox, "id", id);
-        return outbox;
-    }
+	private Outbox buildOutbox(UUID id, OutboxStatus status) {
+		Outbox outbox = Outbox.builder()
+				.correlationId("corr-1")
+				.domainType("ORDER")
+				.eventType("OrderCreatedEvent")
+				.payload("{\"amount\":1000}")
+				.status(status)
+				.build();
+		ReflectionTestUtils.setField(outbox, "id", id);
+		return outbox;
+	}
 }

--- a/src/test/java/com/goggles/common/outbox/OutboxStatusUpdaterTest.java
+++ b/src/test/java/com/goggles/common/outbox/OutboxStatusUpdaterTest.java
@@ -12,7 +12,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.support.SendResult;
-import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.Optional;
 import java.util.UUID;
@@ -28,124 +27,124 @@ import static org.mockito.Mockito.*;
 @ExtendWith(MockitoExtension.class)
 class OutboxStatusUpdaterTest {
 
-    @Mock OutboxRepository outboxRepository;
-    @Mock KafkaTemplate<String, Object> kafkaTemplate;
+	private static final OutboxEvent EVENT =
+			new OutboxEvent("corr-1", "ORDER", "OrderCreatedEvent", "{\"amount\":1000}");
+	@Mock
+	OutboxRepository outboxRepository;
+	@Mock
+	KafkaTemplate<String, Object> kafkaTemplate;
+	@InjectMocks
+	OutboxStatusUpdater updater;
 
-    @InjectMocks
-    OutboxStatusUpdater updater;
+	// ── handleSuccess ─────────────────────────────────────────────────────────
 
-    private static final OutboxEvent EVENT = new OutboxEvent(
-            "corr-1", "ORDER", "OrderCreatedEvent", "{\"amount\":1000}");
+	@Test
+	void handleSuccess_호출시_PROCESSED로_변경된다() {
+		Outbox outbox = buildOutbox();
+		given(outboxRepository.findByCorrelationId("corr-1")).willReturn(Optional.of(outbox));
 
-    // ── handleSuccess ─────────────────────────────────────────────────────────
+		updater.handleSuccess("corr-1");
 
-    @Test
-    void handleSuccess_호출시_PROCESSED로_변경된다() {
-        Outbox outbox = buildOutbox();
-        given(outboxRepository.findByCorrelationId("corr-1")).willReturn(Optional.of(outbox));
+		assertThat(outbox.getStatus()).isEqualTo(OutboxStatus.PROCESSED);
+		verify(outboxRepository).save(outbox);
+	}
 
-        updater.handleSuccess("corr-1");
+	@Test
+	void handleSuccess_outbox가_없으면_아무것도_하지_않는다() {
+		given(outboxRepository.findByCorrelationId("corr-1")).willReturn(Optional.empty());
 
-        assertThat(outbox.getStatus()).isEqualTo(OutboxStatus.PROCESSED);
-        verify(outboxRepository).save(outbox);
-    }
+		updater.handleSuccess("corr-1");
 
-    @Test
-    void handleSuccess_outbox가_없으면_아무것도_하지_않는다() {
-        given(outboxRepository.findByCorrelationId("corr-1")).willReturn(Optional.empty());
+		verify(outboxRepository, never()).save(any());
+	}
 
-        updater.handleSuccess("corr-1");
+	// ── handleFailure ─────────────────────────────────────────────────────────
 
-        verify(outboxRepository, never()).save(any());
-    }
+	@Test
+	void handleFailure_호출시_FAILED로_변경되고_retryCount가_증가한다() {
+		Outbox outbox = buildOutbox();
+		given(outboxRepository.findByCorrelationId("corr-1")).willReturn(Optional.of(outbox));
 
-    // ── handleFailure ─────────────────────────────────────────────────────────
+		updater.handleFailure(EVENT, new RuntimeException("Kafka 오류"));
 
-    @Test
-    void handleFailure_호출시_FAILED로_변경되고_retryCount가_증가한다() {
-        Outbox outbox = buildOutbox();
-        given(outboxRepository.findByCorrelationId("corr-1")).willReturn(Optional.of(outbox));
+		assertThat(outbox.getStatus()).isEqualTo(OutboxStatus.FAILED);
+		assertThat(outbox.getRetryCount()).isEqualTo(1);
+		verify(outboxRepository).saveAndFlush(outbox);
+	}
 
-        updater.handleFailure(EVENT, new RuntimeException("Kafka 오류"));
+	@Test
+	void handleFailure_MAX_RETRY_초과시_DLT로_전송한다() {
+		Outbox outbox = buildOutboxWithRetry(3);
+		given(outboxRepository.findByCorrelationId("corr-1")).willReturn(Optional.of(outbox));
+		given(kafkaTemplate.send(eq("OrderCreatedEvent.DLT"), any())).willReturn(
+				CompletableFuture.completedFuture(mock(SendResult.class)));
 
-        assertThat(outbox.getStatus()).isEqualTo(OutboxStatus.FAILED);
-        assertThat(outbox.getRetryCount()).isEqualTo(1);
-        verify(outboxRepository).saveAndFlush(outbox);
-    }
+		updater.handleFailure(EVENT, new RuntimeException("Kafka 오류"));
 
-    @Test
-    void handleFailure_MAX_RETRY_초과시_DLT로_전송한다() {
-        Outbox outbox = buildOutboxWithRetry(3);
-        given(outboxRepository.findByCorrelationId("corr-1")).willReturn(Optional.of(outbox));
-        given(kafkaTemplate.send(eq("OrderCreatedEvent.DLT"), any()))
-                .willReturn(CompletableFuture.completedFuture(mock(SendResult.class)));
+		verify(kafkaTemplate).send(eq("OrderCreatedEvent.DLT"), any());
+	}
 
-        updater.handleFailure(EVENT, new RuntimeException("Kafka 오류"));
+	@Test
+	void handleFailure_MAX_RETRY_미만이면_DLT로_전송하지_않는다() {
+		Outbox outbox = buildOutbox();
+		given(outboxRepository.findByCorrelationId("corr-1")).willReturn(Optional.of(outbox));
 
-        verify(kafkaTemplate).send(eq("OrderCreatedEvent.DLT"), any());
-    }
+		updater.handleFailure(EVENT, new RuntimeException("Kafka 오류"));
 
-    @Test
-    void handleFailure_MAX_RETRY_미만이면_DLT로_전송하지_않는다() {
-        Outbox outbox = buildOutbox();
-        given(outboxRepository.findByCorrelationId("corr-1")).willReturn(Optional.of(outbox));
+		verifyNoInteractions(kafkaTemplate);
+	}
 
-        updater.handleFailure(EVENT, new RuntimeException("Kafka 오류"));
+	// ── updateRelayStatus ─────────────────────────────────────────────────────
 
-        verifyNoInteractions(kafkaTemplate);
-    }
+	@Test
+	void updateRelayStatus_성공시_PROCESSED로_변경된다() {
+		UUID id = UUID.randomUUID();
+		Outbox outbox = buildOutbox();
+		given(outboxRepository.findById(id)).willReturn(Optional.of(outbox));
 
-    // ── updateRelayStatus ─────────────────────────────────────────────────────
+		updater.updateRelayStatus(id, true);
 
-    @Test
-    void updateRelayStatus_성공시_PROCESSED로_변경된다() {
-        UUID id = UUID.randomUUID();
-        Outbox outbox = buildOutbox();
-        given(outboxRepository.findById(id)).willReturn(Optional.of(outbox));
+		assertThat(outbox.getStatus()).isEqualTo(OutboxStatus.PROCESSED);
+		verify(outboxRepository).saveAndFlush(outbox);
+	}
 
-        updater.updateRelayStatus(id, true);
+	@Test
+	void updateRelayStatus_실패시_FAILED로_변경되고_retryCount가_증가한다() {
+		UUID id = UUID.randomUUID();
+		Outbox outbox = buildOutbox();
+		given(outboxRepository.findById(id)).willReturn(Optional.of(outbox));
 
-        assertThat(outbox.getStatus()).isEqualTo(OutboxStatus.PROCESSED);
-        verify(outboxRepository).saveAndFlush(outbox);
-    }
+		updater.updateRelayStatus(id, false);
 
-    @Test
-    void updateRelayStatus_실패시_FAILED로_변경되고_retryCount가_증가한다() {
-        UUID id = UUID.randomUUID();
-        Outbox outbox = buildOutbox();
-        given(outboxRepository.findById(id)).willReturn(Optional.of(outbox));
+		assertThat(outbox.getStatus()).isEqualTo(OutboxStatus.FAILED);
+		assertThat(outbox.getRetryCount()).isEqualTo(1);
+		verify(outboxRepository).saveAndFlush(outbox);
+	}
 
-        updater.updateRelayStatus(id, false);
+	@Test
+	void updateRelayStatus_outbox가_없으면_아무것도_하지_않는다() {
+		UUID id = UUID.randomUUID();
+		given(outboxRepository.findById(id)).willReturn(Optional.empty());
 
-        assertThat(outbox.getStatus()).isEqualTo(OutboxStatus.FAILED);
-        assertThat(outbox.getRetryCount()).isEqualTo(1);
-        verify(outboxRepository).saveAndFlush(outbox);
-    }
+		updater.updateRelayStatus(id, true);
 
-    @Test
-    void updateRelayStatus_outbox가_없으면_아무것도_하지_않는다() {
-        UUID id = UUID.randomUUID();
-        given(outboxRepository.findById(id)).willReturn(Optional.empty());
+		verify(outboxRepository, never()).saveAndFlush(any());
+	}
 
-        updater.updateRelayStatus(id, true);
+	// ── helpers ───────────────────────────────────────────────────────────────
 
-        verify(outboxRepository, never()).saveAndFlush(any());
-    }
+	private Outbox buildOutbox() {
+		return Outbox.builder()
+				.correlationId("corr-1")
+				.domainType("ORDER")
+				.eventType("OrderCreatedEvent")
+				.payload("{\"amount\":1000}")
+				.build();
+	}
 
-    // ── helpers ───────────────────────────────────────────────────────────────
-
-    private Outbox buildOutbox() {
-        return Outbox.builder()
-                .correlationId("corr-1")
-                .domainType("ORDER")
-                .eventType("OrderCreatedEvent")
-                .payload("{\"amount\":1000}")
-                .build();
-    }
-
-    private Outbox buildOutboxWithRetry(int retryCount) {
-        Outbox outbox = buildOutbox();
-        for (int i = 0; i < retryCount; i++) outbox.fail();
-        return outbox;
-    }
+	private Outbox buildOutboxWithRetry(int retryCount) {
+		Outbox outbox = buildOutbox();
+		for (int i = 0; i < retryCount; i++) outbox.fail();
+		return outbox;
+	}
 }

--- a/src/test/java/com/goggles/common/outbox/OutboxStatusUpdaterTest.java
+++ b/src/test/java/com/goggles/common/outbox/OutboxStatusUpdaterTest.java
@@ -1,0 +1,151 @@
+package com.goggles.common.outbox;
+
+import com.goggles.common.domain.Outbox;
+import com.goggles.common.domain.OutboxRepository;
+import com.goggles.common.domain.OutboxStatus;
+import com.goggles.common.event.OutboxEvent;
+import com.goggles.common.event.OutboxStatusUpdater;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@SuppressWarnings("unchecked")
+@ExtendWith(MockitoExtension.class)
+class OutboxStatusUpdaterTest {
+
+    @Mock OutboxRepository outboxRepository;
+    @Mock KafkaTemplate<String, Object> kafkaTemplate;
+
+    @InjectMocks
+    OutboxStatusUpdater updater;
+
+    private static final OutboxEvent EVENT = new OutboxEvent(
+            "corr-1", "ORDER", "OrderCreatedEvent", "{\"amount\":1000}");
+
+    // ── handleSuccess ─────────────────────────────────────────────────────────
+
+    @Test
+    void handleSuccess_호출시_PROCESSED로_변경된다() {
+        Outbox outbox = buildOutbox();
+        given(outboxRepository.findByCorrelationId("corr-1")).willReturn(Optional.of(outbox));
+
+        updater.handleSuccess("corr-1");
+
+        assertThat(outbox.getStatus()).isEqualTo(OutboxStatus.PROCESSED);
+        verify(outboxRepository).save(outbox);
+    }
+
+    @Test
+    void handleSuccess_outbox가_없으면_아무것도_하지_않는다() {
+        given(outboxRepository.findByCorrelationId("corr-1")).willReturn(Optional.empty());
+
+        updater.handleSuccess("corr-1");
+
+        verify(outboxRepository, never()).save(any());
+    }
+
+    // ── handleFailure ─────────────────────────────────────────────────────────
+
+    @Test
+    void handleFailure_호출시_FAILED로_변경되고_retryCount가_증가한다() {
+        Outbox outbox = buildOutbox();
+        given(outboxRepository.findByCorrelationId("corr-1")).willReturn(Optional.of(outbox));
+
+        updater.handleFailure(EVENT, new RuntimeException("Kafka 오류"));
+
+        assertThat(outbox.getStatus()).isEqualTo(OutboxStatus.FAILED);
+        assertThat(outbox.getRetryCount()).isEqualTo(1);
+        verify(outboxRepository).saveAndFlush(outbox);
+    }
+
+    @Test
+    void handleFailure_MAX_RETRY_초과시_DLT로_전송한다() {
+        Outbox outbox = buildOutboxWithRetry(3);
+        given(outboxRepository.findByCorrelationId("corr-1")).willReturn(Optional.of(outbox));
+        given(kafkaTemplate.send(eq("OrderCreatedEvent.DLT"), any()))
+                .willReturn(CompletableFuture.completedFuture(mock(SendResult.class)));
+
+        updater.handleFailure(EVENT, new RuntimeException("Kafka 오류"));
+
+        verify(kafkaTemplate).send(eq("OrderCreatedEvent.DLT"), any());
+    }
+
+    @Test
+    void handleFailure_MAX_RETRY_미만이면_DLT로_전송하지_않는다() {
+        Outbox outbox = buildOutbox();
+        given(outboxRepository.findByCorrelationId("corr-1")).willReturn(Optional.of(outbox));
+
+        updater.handleFailure(EVENT, new RuntimeException("Kafka 오류"));
+
+        verifyNoInteractions(kafkaTemplate);
+    }
+
+    // ── updateRelayStatus ─────────────────────────────────────────────────────
+
+    @Test
+    void updateRelayStatus_성공시_PROCESSED로_변경된다() {
+        UUID id = UUID.randomUUID();
+        Outbox outbox = buildOutbox();
+        given(outboxRepository.findById(id)).willReturn(Optional.of(outbox));
+
+        updater.updateRelayStatus(id, true);
+
+        assertThat(outbox.getStatus()).isEqualTo(OutboxStatus.PROCESSED);
+        verify(outboxRepository).saveAndFlush(outbox);
+    }
+
+    @Test
+    void updateRelayStatus_실패시_FAILED로_변경되고_retryCount가_증가한다() {
+        UUID id = UUID.randomUUID();
+        Outbox outbox = buildOutbox();
+        given(outboxRepository.findById(id)).willReturn(Optional.of(outbox));
+
+        updater.updateRelayStatus(id, false);
+
+        assertThat(outbox.getStatus()).isEqualTo(OutboxStatus.FAILED);
+        assertThat(outbox.getRetryCount()).isEqualTo(1);
+        verify(outboxRepository).saveAndFlush(outbox);
+    }
+
+    @Test
+    void updateRelayStatus_outbox가_없으면_아무것도_하지_않는다() {
+        UUID id = UUID.randomUUID();
+        given(outboxRepository.findById(id)).willReturn(Optional.empty());
+
+        updater.updateRelayStatus(id, true);
+
+        verify(outboxRepository, never()).saveAndFlush(any());
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    private Outbox buildOutbox() {
+        return Outbox.builder()
+                .correlationId("corr-1")
+                .domainType("ORDER")
+                .eventType("OrderCreatedEvent")
+                .payload("{\"amount\":1000}")
+                .build();
+    }
+
+    private Outbox buildOutboxWithRetry(int retryCount) {
+        Outbox outbox = buildOutbox();
+        for (int i = 0; i < retryCount; i++) outbox.fail();
+        return outbox;
+    }
+}

--- a/src/test/java/com/goggles/common/outbox/OutboxTest.java
+++ b/src/test/java/com/goggles/common/outbox/OutboxTest.java
@@ -1,0 +1,62 @@
+package com.goggles.common.outbox;
+
+import com.goggles.common.domain.Outbox;
+import com.goggles.common.domain.OutboxStatus;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OutboxTest {
+
+    private Outbox buildOutbox() {
+        return Outbox.builder()
+                .correlationId("corr-1")
+                .domainType("ORDER")
+                .eventType("OrderCreatedEvent")
+                .payload("{\"amount\":1000}")
+                .build();
+    }
+
+    @Test
+    void 기본_상태는_PENDING이고_retryCount는_0이다() {
+        Outbox outbox = buildOutbox();
+
+        assertThat(outbox.getStatus()).isEqualTo(OutboxStatus.PENDING);
+        assertThat(outbox.getRetryCount()).isZero();
+    }
+
+    @Test
+    void processing_호출시_상태가_PROCESSING으로_변경된다() {
+        Outbox outbox = buildOutbox();
+        outbox.processing();
+
+        assertThat(outbox.getStatus()).isEqualTo(OutboxStatus.PROCESSING);
+    }
+
+    @Test
+    void complete_호출시_상태가_PROCESSED로_변경된다() {
+        Outbox outbox = buildOutbox();
+        outbox.complete();
+
+        assertThat(outbox.getStatus()).isEqualTo(OutboxStatus.PROCESSED);
+    }
+
+    @Test
+    void fail_호출시_상태가_FAILED로_변경되고_retryCount가_증가한다() {
+        Outbox outbox = buildOutbox();
+        outbox.fail();
+
+        assertThat(outbox.getStatus()).isEqualTo(OutboxStatus.FAILED);
+        assertThat(outbox.getRetryCount()).isEqualTo(1);
+    }
+
+    @Test
+    void fail_여러번_호출시_retryCount가_누적된다() {
+        Outbox outbox = buildOutbox();
+        outbox.fail();
+        outbox.fail();
+        outbox.fail();
+
+        assertThat(outbox.getRetryCount()).isEqualTo(3);
+    }
+}

--- a/src/test/java/com/goggles/common/outbox/OutboxTest.java
+++ b/src/test/java/com/goggles/common/outbox/OutboxTest.java
@@ -8,55 +8,55 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class OutboxTest {
 
-    private Outbox buildOutbox() {
-        return Outbox.builder()
-                .correlationId("corr-1")
-                .domainType("ORDER")
-                .eventType("OrderCreatedEvent")
-                .payload("{\"amount\":1000}")
-                .build();
-    }
+	private Outbox buildOutbox() {
+		return Outbox.builder()
+				.correlationId("corr-1")
+				.domainType("ORDER")
+				.eventType("OrderCreatedEvent")
+				.payload("{\"amount\":1000}")
+				.build();
+	}
 
-    @Test
-    void 기본_상태는_PENDING이고_retryCount는_0이다() {
-        Outbox outbox = buildOutbox();
+	@Test
+	void 기본_상태는_PENDING이고_retryCount는_0이다() {
+		Outbox outbox = buildOutbox();
 
-        assertThat(outbox.getStatus()).isEqualTo(OutboxStatus.PENDING);
-        assertThat(outbox.getRetryCount()).isZero();
-    }
+		assertThat(outbox.getStatus()).isEqualTo(OutboxStatus.PENDING);
+		assertThat(outbox.getRetryCount()).isZero();
+	}
 
-    @Test
-    void processing_호출시_상태가_PROCESSING으로_변경된다() {
-        Outbox outbox = buildOutbox();
-        outbox.processing();
+	@Test
+	void processing_호출시_상태가_PROCESSING으로_변경된다() {
+		Outbox outbox = buildOutbox();
+		outbox.processing();
 
-        assertThat(outbox.getStatus()).isEqualTo(OutboxStatus.PROCESSING);
-    }
+		assertThat(outbox.getStatus()).isEqualTo(OutboxStatus.PROCESSING);
+	}
 
-    @Test
-    void complete_호출시_상태가_PROCESSED로_변경된다() {
-        Outbox outbox = buildOutbox();
-        outbox.complete();
+	@Test
+	void complete_호출시_상태가_PROCESSED로_변경된다() {
+		Outbox outbox = buildOutbox();
+		outbox.complete();
 
-        assertThat(outbox.getStatus()).isEqualTo(OutboxStatus.PROCESSED);
-    }
+		assertThat(outbox.getStatus()).isEqualTo(OutboxStatus.PROCESSED);
+	}
 
-    @Test
-    void fail_호출시_상태가_FAILED로_변경되고_retryCount가_증가한다() {
-        Outbox outbox = buildOutbox();
-        outbox.fail();
+	@Test
+	void fail_호출시_상태가_FAILED로_변경되고_retryCount가_증가한다() {
+		Outbox outbox = buildOutbox();
+		outbox.fail();
 
-        assertThat(outbox.getStatus()).isEqualTo(OutboxStatus.FAILED);
-        assertThat(outbox.getRetryCount()).isEqualTo(1);
-    }
+		assertThat(outbox.getStatus()).isEqualTo(OutboxStatus.FAILED);
+		assertThat(outbox.getRetryCount()).isEqualTo(1);
+	}
 
-    @Test
-    void fail_여러번_호출시_retryCount가_누적된다() {
-        Outbox outbox = buildOutbox();
-        outbox.fail();
-        outbox.fail();
-        outbox.fail();
+	@Test
+	void fail_여러번_호출시_retryCount가_누적된다() {
+		Outbox outbox = buildOutbox();
+		outbox.fail();
+		outbox.fail();
+		outbox.fail();
 
-        assertThat(outbox.getRetryCount()).isEqualTo(3);
-    }
+		assertThat(outbox.getRetryCount()).isEqualTo(3);
+	}
 }


### PR DESCRIPTION
 MSA 공통 라이브러리 초기 구현 
  ---                                                                                                                                                        
MSA 환경에서 여러 서비스가 공통으로 사용할 수 있는 라이브러리 초기 버전을 구현합니다.                                                                    
Outbox/Inbox 패턴, 공통 예외 처리, 응답 포맷, 페이지네이션, MDC 요청 추적 기능을 포함합니다.                                                                                                                                                        
  ---                                                                                                                                                        

  주요 변경 사항                                                                                                                                             
1. Base Entity
  - BaseTime: 생성/수정/삭제 시각 + soft delete 지원
  - BaseAudit: BaseTime 확장, 생성자/수정자/삭제자 UUID 추적 (AuditorAware 필요)                                                                             

 2. Outbox / Inbox 패턴 (Kafka 이벤트 신뢰성 보장)                                                                                                          
  - Outbox 엔티티 및 OutboxEventListener: 도메인 이벤트를 DB에 먼저 저장                                                                                     
  - OutboxRelayScheduler: 미발행 이벤트를 주기적으로 Kafka에 발행                                                                                            
  - OutboxStatusUpdater: 발행 성공/실패 상태 업데이트                                                                                                        
  - InboxAdvice (@IdempotentConsumer): AOP 기반 중복 메시지 방지                                                                                             
  - InboxCleanupScheduler: 오래된 Inbox 레코드 정리                                                                                                          

 3. 예외 처리                                                                                                                                               
  - CustomException 계층 구조: BadRequestException, NotFoundException, ConflictException, ForbiddenException, UnAuthorizedException, InternalServerException 
  - GlobalExceptionAdvice: 통합 예외 핸들러, ErrorResponse 포맷으로 응답                                                                                     

  4. 공통 응답 포맷                                                                                                                                          
  - ApiResponse<T>: 성공/실패 응답 래퍼                                                                                                                      
  - CommonResponseAdvice: @RestController 응답 자동 래핑                                                                                                     

 5. 페이지네이션                                                                                                                                            
  - Offset 기반: CommonPageRequest / CommonPageResponse
  - Cursor 기반: CommonCursorRequest / CommonCursorResponse                                                                                                  
  - 각각 ArgumentResolver 등록                             

 6. MDC 요청 추적                                                                                                                                           
  - MdcLoggingFilter: correlationId를 MDC에 주입 (헤더에서 전파 또는 신규 생성)
  - MdcTaskDecorator: 비동기 스레드로 MDC 컨텍스트 전파                                                                                                                                    

  8. 테스트                                                                                                                                                  
  - GlobalExceptionHandlerTest, PageResponseTest                                                                                                             
  - OutboxEventListenerTest, OutboxStatusUpdaterTest, OutboxTest                                                                                             

 ---                                                                                                                                                        
  리뷰어 확인 포인트                                                                                               
  - OutboxRelayScheduler의 재시도 로직 및 최대 재시도 횟수 정책                                                                                              
  - InboxAdvice의 @IdempotentConsumer AOP 적용 범위 (소비자 서비스에서 @EnableAspectJAutoProxy 필요)  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 이벤트 발행 및 메시지 처리 패턴 구현
  * 페이지네이션 기능 추가 (오프셋 및 커서 기반)
  * MDC 기반 요청 추적 기능
  * 소프트 삭제 지원
  * 강화된 예외 처리 및 표준 응답 포맷

* **문서**
  * README 대폭 확장: 설정 가이드, 예외 처리, 응답 포맷, 페이지네이션, 요청 추적 문서화

* **테스트**
  * 예외 처리, 페이지네이션, 이벤트 처리 관련 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->