### PR TITLE
[FIX] EventConfig 분리 및 AutoConfiguration 구조로 전환

### DIFF
--- a/src/main/java/com/goggles/config/event/AsyncConfig.java
+++ b/src/main/java/com/goggles/config/event/AsyncConfig.java
@@ -1,0 +1,32 @@
+package com.goggles.config.event;
+
+import com.goggles.common.util.MdcTaskDecorator;
+import java.util.concurrent.Executor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.security.task.DelegatingSecurityContextAsyncTaskExecutor;
+
+@EnableAsync
+@EnableScheduling
+@EnableAspectJAutoProxy(proxyTargetClass = true)
+@Configuration
+public class AsyncConfig implements AsyncConfigurer {
+
+  @Override
+  public Executor getAsyncExecutor() {
+    ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+    executor.setCorePoolSize(10);
+    executor.setMaxPoolSize(50);
+    executor.setQueueCapacity(100);
+    executor.setThreadNamePrefix("Async-");
+    executor.setTaskDecorator(new MdcTaskDecorator());
+    executor.setWaitForTasksToCompleteOnShutdown(true);
+    executor.setAwaitTerminationSeconds(60);
+    executor.initialize();
+    return new DelegatingSecurityContextAsyncTaskExecutor(executor);
+  }
+}

--- a/src/main/java/com/goggles/config/event/EventConfig.java
+++ b/src/main/java/com/goggles/config/event/EventConfig.java
@@ -1,110 +1,16 @@
 package com.goggles.config.event;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.goggles.common.domain.InboxRepository;
-import com.goggles.common.domain.OutboxRepository;
 import com.goggles.common.event.Events;
-import com.goggles.common.event.OutboxEventListener;
-import com.goggles.common.event.OutboxStatusUpdater;
-import com.goggles.common.event.advice.InboxAdvice;
-import com.goggles.common.event.scheduler.InboxCleanupScheduler;
-import com.goggles.common.event.scheduler.OutboxRelayScheduler;
-import com.goggles.common.filter.MdcLoggingFilter;
-import com.goggles.common.pagination.CommonCursorRequestArgumentResolver;
-import com.goggles.common.pagination.CommonPageRequestArgumentResolver;
-import com.goggles.common.util.MdcTaskDecorator;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.EnableAspectJAutoProxy;
-import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.scheduling.annotation.AsyncConfigurer;
-import org.springframework.scheduling.annotation.EnableAsync;
-import org.springframework.scheduling.annotation.EnableScheduling;
-import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
-import org.springframework.security.task.DelegatingSecurityContextAsyncTaskExecutor;
-import org.springframework.web.method.support.HandlerMethodArgumentResolver;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
-import java.util.List;
-import java.util.concurrent.Executor;
-
-@EnableAsync
 @Configuration
-@EnableScheduling
-@EnableAspectJAutoProxy(proxyTargetClass = true)
 public class EventConfig implements AsyncConfigurer {
-
-	// ── Event ────────────────────────────────────────────────────────────────
 
 	@Bean
 	public Events events(ApplicationEventPublisher eventPublisher) {
 		return new Events(eventPublisher);
-	}
-
-	@Bean
-	public OutboxStatusUpdater outboxStatusUpdater(OutboxRepository outboxRepository,
-			KafkaTemplate<String, Object> kafkaTemplate) {
-		return new OutboxStatusUpdater(outboxRepository, kafkaTemplate);
-	}
-
-	@Bean
-	public OutboxEventListener outboxEventListener(OutboxRepository outboxRepository,
-			KafkaTemplate<String, Object> kafkaTemplate, ObjectMapper objectMapper,
-			OutboxStatusUpdater outboxStatusUpdater) {
-		return new OutboxEventListener(outboxRepository, kafkaTemplate, objectMapper,
-				outboxStatusUpdater);
-	}
-
-	@Bean
-	public OutboxRelayScheduler outboxRelayScheduler(OutboxRepository outboxRepository,
-			KafkaTemplate<String, Object> kafkaTemplate, OutboxStatusUpdater outboxStatusUpdater) {
-		return new OutboxRelayScheduler(outboxRepository, kafkaTemplate, outboxStatusUpdater);
-	}
-
-	@Bean
-	public InboxAdvice inboxAdvice(InboxRepository inboxRepository) {
-		return new InboxAdvice(inboxRepository);
-	}
-
-	@Bean
-	public InboxCleanupScheduler inboxCleanupScheduler(InboxRepository inboxRepository) {
-		return new InboxCleanupScheduler(inboxRepository);
-	}
-
-	// ── Filter ───────────────────────────────────────────────────────────────
-
-	@Bean
-	public MdcLoggingFilter mdcLoggingFilter() {
-		return new MdcLoggingFilter();
-	}
-
-	// ── ArgumentResolver ─────────────────────────────────────────────────────
-
-	@Bean
-	public WebMvcConfigurer commonArgumentResolverConfigurer() {
-		return new WebMvcConfigurer() {
-			@Override
-			public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
-				resolvers.add(new CommonPageRequestArgumentResolver());
-				resolvers.add(new CommonCursorRequestArgumentResolver());
-			}
-		};
-	}
-
-	// ── Async ────────────────────────────────────────────────────────────────
-
-	@Override
-	public Executor getAsyncExecutor() {
-		ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
-		executor.setCorePoolSize(10);
-		executor.setMaxPoolSize(50);
-		executor.setQueueCapacity(100);
-		executor.setThreadNamePrefix("Async-");
-		executor.setTaskDecorator(new MdcTaskDecorator());
-		executor.setWaitForTasksToCompleteOnShutdown(true);
-		executor.setAwaitTerminationSeconds(60);
-		executor.initialize();
-		return new DelegatingSecurityContextAsyncTaskExecutor(executor);
 	}
 }

--- a/src/main/java/com/goggles/config/event/EventConfig.java
+++ b/src/main/java/com/goggles/config/event/EventConfig.java
@@ -7,7 +7,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.AsyncConfigurer;
 
 @Configuration
-public class EventConfig implements AsyncConfigurer {
+public class EventConfig {
 
 	@Bean
 	public Events events(ApplicationEventPublisher eventPublisher) {

--- a/src/main/java/com/goggles/config/event/OutboxConfig.java
+++ b/src/main/java/com/goggles/config/event/OutboxConfig.java
@@ -14,15 +14,17 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.core.KafkaTemplate;
 
 @Configuration
-@ConditionalOnBean(type = "org.springframework.kafka.core.KafkaTemplate")
 public class OutboxConfig {
+
   @Bean
+  @ConditionalOnBean(type = "org.springframework.kafka.core.KafkaTemplate")
   public OutboxStatusUpdater outboxStatusUpdater(OutboxRepository outboxRepository,
       KafkaTemplate<String, Object> kafkaTemplate) {
     return new OutboxStatusUpdater(outboxRepository, kafkaTemplate);
   }
 
   @Bean
+  @ConditionalOnBean(type = "org.springframework.kafka.core.KafkaTemplate")
   public OutboxEventListener outboxEventListener(OutboxRepository outboxRepository,
       KafkaTemplate<String, Object> kafkaTemplate, ObjectMapper objectMapper,
       OutboxStatusUpdater outboxStatusUpdater) {
@@ -31,17 +33,20 @@ public class OutboxConfig {
   }
 
   @Bean
+  @ConditionalOnBean(type = "org.springframework.kafka.core.KafkaTemplate")
   public OutboxRelayScheduler outboxRelayScheduler(OutboxRepository outboxRepository,
       KafkaTemplate<String, Object> kafkaTemplate, OutboxStatusUpdater outboxStatusUpdater) {
     return new OutboxRelayScheduler(outboxRepository, kafkaTemplate, outboxStatusUpdater);
   }
 
   @Bean
+  @ConditionalOnBean(type = "org.springframework.kafka.core.KafkaTemplate")
   public InboxAdvice inboxAdvice(InboxRepository inboxRepository) {
     return new InboxAdvice(inboxRepository);
   }
 
   @Bean
+  @ConditionalOnBean(type = "org.springframework.kafka.core.KafkaTemplate")
   public InboxCleanupScheduler inboxCleanupScheduler(InboxRepository inboxRepository) {
     return new InboxCleanupScheduler(inboxRepository);
   }

--- a/src/main/java/com/goggles/config/event/OutboxConfig.java
+++ b/src/main/java/com/goggles/config/event/OutboxConfig.java
@@ -1,0 +1,48 @@
+package com.goggles.config.event;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.goggles.common.domain.InboxRepository;
+import com.goggles.common.domain.OutboxRepository;
+import com.goggles.common.event.OutboxEventListener;
+import com.goggles.common.event.OutboxStatusUpdater;
+import com.goggles.common.event.advice.InboxAdvice;
+import com.goggles.common.event.scheduler.InboxCleanupScheduler;
+import com.goggles.common.event.scheduler.OutboxRelayScheduler;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.KafkaTemplate;
+
+@Configuration
+@ConditionalOnBean(type = "org.springframework.kafka.core.KafkaTemplate")
+public class OutboxConfig {
+  @Bean
+  public OutboxStatusUpdater outboxStatusUpdater(OutboxRepository outboxRepository,
+      KafkaTemplate<String, Object> kafkaTemplate) {
+    return new OutboxStatusUpdater(outboxRepository, kafkaTemplate);
+  }
+
+  @Bean
+  public OutboxEventListener outboxEventListener(OutboxRepository outboxRepository,
+      KafkaTemplate<String, Object> kafkaTemplate, ObjectMapper objectMapper,
+      OutboxStatusUpdater outboxStatusUpdater) {
+    return new OutboxEventListener(outboxRepository, kafkaTemplate, objectMapper,
+        outboxStatusUpdater);
+  }
+
+  @Bean
+  public OutboxRelayScheduler outboxRelayScheduler(OutboxRepository outboxRepository,
+      KafkaTemplate<String, Object> kafkaTemplate, OutboxStatusUpdater outboxStatusUpdater) {
+    return new OutboxRelayScheduler(outboxRepository, kafkaTemplate, outboxStatusUpdater);
+  }
+
+  @Bean
+  public InboxAdvice inboxAdvice(InboxRepository inboxRepository) {
+    return new InboxAdvice(inboxRepository);
+  }
+
+  @Bean
+  public InboxCleanupScheduler inboxCleanupScheduler(InboxRepository inboxRepository) {
+    return new InboxCleanupScheduler(inboxRepository);
+  }
+}

--- a/src/main/java/com/goggles/config/web/WebConfig.java
+++ b/src/main/java/com/goggles/config/web/WebConfig.java
@@ -1,0 +1,19 @@
+package com.goggles.config.web;
+
+import com.goggles.common.pagination.CommonCursorRequestArgumentResolver;
+import java.util.List;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication.Type;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@ConditionalOnWebApplication(type = Type.SERVLET)
+public class WebConfig implements WebMvcConfigurer {
+
+  @Override
+  public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+    resolvers.add(new CommonCursorRequestArgumentResolver());
+  }
+}

--- a/src/main/java/com/goggles/config/web/WebSupportConfig.java
+++ b/src/main/java/com/goggles/config/web/WebSupportConfig.java
@@ -1,19 +1,28 @@
 package com.goggles.config.web;
 
+import com.goggles.common.filter.MdcLoggingFilter;
 import com.goggles.common.pagination.CommonCursorRequestArgumentResolver;
+import com.goggles.common.pagination.CommonPageRequestArgumentResolver;
 import java.util.List;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication.Type;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
 @ConditionalOnWebApplication(type = Type.SERVLET)
-public class WebConfig implements WebMvcConfigurer {
+public class WebSupportConfig implements WebMvcConfigurer {
+
+  @Bean
+  public MdcLoggingFilter mdcLoggingFilter() {
+    return new MdcLoggingFilter();
+  }
 
   @Override
   public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+    resolvers.add(new CommonPageRequestArgumentResolver());
     resolvers.add(new CommonCursorRequestArgumentResolver());
   }
 }

--- a/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,3 @@
+com.goggles.config.web.WebSupportConfig
+com.goggles.config.event.AsyncConfig
+com.goggles.config.event.EventConfig


### PR DESCRIPTION
## 요약
#4
EventConfig에 포함되어 있던 설정들을 역할에 맞게 분리하고,
AutoConfiguration.imports에 등록하여 자동 주입되도록 구조를 개선했습니다.
OutboxConfig는 Kafka 의존성이 필요한 경우에만 선택적으로 사용할 수 있도록 제외했습니다.

## 변경사항

* EventConfig 내부 설정을 역할별 Config로 분리

  * EventPublisherConfig
  * WebSupportConfig
  * AsyncConfig
  * OutboxConfig
* META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports에 등록하여 자동 주입되도록 수정
* OutboxConfig는 Kafka 사용 여부에 따라 선택적으로 적용할 수 있도록 AutoConfiguration 대상에서 제외


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Kafka가 있는 환경에서만 아웃박스/인박스 전달 및 스케줄링 활성화
  * 서블릿 웹 환경용 페이지/커서 요청 파라미터 해석기와 MDC 로깅 필터 추가
  * 비동기 처리 및 스케줄링 설정 추가로 백그라운드 작업 실행 개선

* **Refactor**
  * 이벤트·웹 관련 설정을 더 작은 구성 단위로 분리하여 유지보수성 향상

* **Chores**
  * 새 구성 클래스들을 자동구성 목록에 등록
<!-- end of auto-generated comment: release notes by coderabbit.ai -->