### PR TITLE
fix: outbox fail() 호출 시점 재처리 수행을 위한 Instant 타입 update 필드 추가

### DIFF
--- a/src/main/java/com/goggles/common/domain/Outbox.java
+++ b/src/main/java/com/goggles/common/domain/Outbox.java
@@ -50,6 +50,10 @@ public class Outbox {
 	@Column(updatable = false)
 	private Instant createdAt;
 
+	@LastModifiedDate
+	@Column
+	private Instant updatedAt;
+
 	private Instant processedAt;
 
 	public void processing() {

--- a/src/main/java/com/goggles/common/domain/OutboxRepository.java
+++ b/src/main/java/com/goggles/common/domain/OutboxRepository.java
@@ -1,5 +1,6 @@
 package com.goggles.common.domain;
 
+import java.time.Instant;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDateTime;
@@ -10,7 +11,7 @@ import java.util.UUID;
 public interface OutboxRepository extends JpaRepository<Outbox, UUID> {
 	List<Outbox> findByStatusInAndRetryCountLessThan(List<OutboxStatus> statuses, int limit);
 
-	List<Outbox> findByStatusAndUpdatedAtBefore(OutboxStatus status, LocalDateTime threshold);
+	List<Outbox> findByStatusAndUpdatedAtBefore(OutboxStatus status, Instant threshold);
 
 	Optional<Outbox> findByCorrelationId(String correlationId);
 

--- a/src/main/java/com/goggles/common/event/scheduler/OutboxRelayScheduler.java
+++ b/src/main/java/com/goggles/common/event/scheduler/OutboxRelayScheduler.java
@@ -5,6 +5,7 @@ import com.goggles.common.domain.Outbox;
 import com.goggles.common.domain.OutboxRepository;
 import com.goggles.common.domain.OutboxStatus;
 import com.goggles.common.event.OutboxStatusUpdater;
+import java.time.Instant;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.core.KafkaTemplate;
@@ -37,8 +38,7 @@ public class OutboxRelayScheduler {
 		// 서버 재시작 등으로 PROCESSING 상태가 일정 시간 이상 유지된 row 복구
 		List<Outbox> stuckTargets =
 				outboxRepository.findByStatusAndUpdatedAtBefore(OutboxStatus.PROCESSING,
-						LocalDateTime.now()
-								.minusMinutes(PROCESSING_STUCK_MINUTES));
+						Instant.now().minusSeconds(PROCESSING_STUCK_MINUTES * 60));
 		if (!stuckTargets.isEmpty()) {
 			log.warn("[Outbox] PROCESSING stuck 감지 {}건 — 재처리합니다", stuckTargets.size());
 			targets.addAll(stuckTargets);


### PR DESCRIPTION
- outbox 엔티티 LocalDateTime -> Instant로 변경되면서 findByStatusAndUpdatedAtBefore() 실행 불가 문제 발생
- outbox 엔티티에 Instant updateAt  필드 추가
- findByStatusAndUpdatedAtBefore(OutboxStatus status, Instant threshold); 로 변경